### PR TITLE
Fluentd With Multiple Destinations

### DIFF
--- a/Images/fluentd-aggregator/Dockerfile
+++ b/Images/fluentd-aggregator/Dockerfile
@@ -23,6 +23,7 @@ RUN set -eu; \
   fluent-plugin-record-modifier \
   fluent-plugin-rewrite-tag-filter \
   fluent-plugin-route \
+  fluent-plugin-label-router \
   fluent-plugin-s3 \
   fluent-plugin-sqs; \
   sudo gem sources --clear-all; \

--- a/Images/fluentd-aggregator/fluent.conf
+++ b/Images/fluentd-aggregator/fluent.conf
@@ -1,0 +1,23 @@
+<source>
+  @type  forward
+  @id    input
+  @label @mainstream
+  port  24224
+  bind 0.0.0.0
+</source>
+
+<label @FLUENT_LOG>
+  <match fluent.*>
+    @type stdout
+  </match>
+</label>
+
+<filter **>
+  @type stdout
+</filter>
+
+<label @mainstream>
+  <match **>
+    @type null
+  </match>
+</label>

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ kubectl apply -f logging/fluent-bit-daemonset-forward-minikube.yaml
 #### Install Fluentd statefulset as a log aggregator
 
 ```shell
+cd Images/fluentd-aggregator/
+export IMG=localhost:5000/fluentd
+docker build -t $IMG .
+docker push $IMG
+cd ../..
+```
+
+```shell
 kubectl apply -f logging/fluentd-aggregator-configmap.yaml
 kubectl apply -f logging/fluentd-aggregator-service.yaml
 kubectl apply -f logging/fluentd-aggregator-statefulset.yaml

--- a/logging/fluentd-aggregator-configmap.yaml
+++ b/logging/fluentd-aggregator-configmap.yaml
@@ -8,44 +8,63 @@ data:
     </source>
 
     <match **>
-       @type elasticsearch
-       @id out_es
-       @log_level info
-       include_tag_key true
-       host a8s-opendistro-es-client-service.a8s-system.svc.cluster.local
-       port 9200
-       scheme 'http'
-       ssl_verify 'true'
-       ssl_version 'TLSv1_2'
-       user 'admin'
-       password 'admin'
-       reload_connections 'false'
-       reconnect_on_error 'true'
-       reload_on_failure 'true'
-       log_es_400_reason 'false'
-       logstash_prefix 'logstash'
-       logstash_dateformat '%Y.%m.%d'
-       logstash_format 'true'
-       index_name 'logstash'
-       target_index_key use_nil
-       type_name 'fluentd'
-       include_timestamp 'false'
-       request_timeout '5s'
-       application_name use_default
-       suppress_type_name 'true'
-       enable_ilm 'false'
-       ilm_policy_id use_default
-       ilm_policy use_default
-       ilm_policy_overwrite 'false'
-       <buffer>
-         flush_thread_count '8'
-         flush_interval '5s'
-         chunk_limit_size '2M'
-         queue_limit_length '32'
-         retry_max_interval '30'
-         retry_forever true
-       </buffer>
+      @type copy
+      <store>
+        @type label_router
+        <route>
+          @label @POSTGRES
+          tag postgres_tag
+          <match>
+            labels cluster-name:sample-pg-cluster
+          </match>
+        </route>
+      </store>
+      <store>
+         @type elasticsearch
+         @id out_es
+         @log_level info
+         include_tag_key true
+         host a8s-opendistro-es-client-service.a8s-system.svc.cluster.local
+         port 9200
+         scheme 'http'
+         ssl_verify 'true'
+         ssl_version 'TLSv1_2'
+         user 'admin'
+         password 'admin'
+         reload_connections 'false'
+         reconnect_on_error 'true'
+         reload_on_failure 'true'
+         log_es_400_reason 'false'
+         logstash_prefix 'logstash'
+         logstash_dateformat '%Y.%m.%d'
+         logstash_format 'true'
+         index_name 'logstash'
+         target_index_key use_nil
+         type_name 'fluentd'
+         include_timestamp 'false'
+         request_timeout '5s'
+         application_name use_default
+         suppress_type_name 'true'
+         enable_ilm 'false'
+         ilm_policy_id use_default
+         ilm_policy use_default
+         ilm_policy_overwrite 'false'
+         <buffer>
+           flush_thread_count '8'
+           flush_interval '5s'
+           chunk_limit_size '2M'
+           queue_limit_length '32'
+           retry_max_interval '30'
+           retry_forever true
+         </buffer>
+      </store>
     </match>
+
+    <label @POSTGRES>
+      <match **>
+        @type stdout
+      </match>
+    </label>
 kind: ConfigMap
 metadata:
   labels:

--- a/logging/fluentd-aggregator-statefulset.yaml
+++ b/logging/fluentd-aggregator-statefulset.yaml
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/name: fluentd-aggregator
     spec:
       containers:
-      - image: ghcr.io/stevehipwell/fluentd-aggregator:1.12.4
+      - image: "localhost:5000/fluentd"
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/operational-models/logging/README.md
+++ b/operational-models/logging/README.md
@@ -31,7 +31,7 @@ The filename already provides some valuable information. For example the
 `counter` pod is running in namespace `default` and has container id
 `d171c94305d25168402747e06ec0489f5f11b520388c01796450db3e224337d8`.
 
-The log files themself are in `json` file format. They contain the following
+The log files themselves are in `json` file format. They contain the following
 fields:
 - log
 - stream
@@ -60,8 +60,14 @@ minikube.
 ### Creation
 
 First we need to install the Fluent Bit daemonset.
-It is configured in a way that it forwards the processed logs to an
-Elasticsearch instance.
+It is configured in a way that it forwards the processed logs to a central
+Fluentd instance. Fluent Bit works best as a forwarder given its designed with
+performance in mind: high throughput with low CPU and Memory usage. We run it
+as a daemonset which ensures that all (or some) Nodes run a copy of a
+Pod. As nodes are added to the cluster, Pods are added to them. As nodes are
+removed from the cluster, those Pods are garbage collected. This is important
+given each Fluent Bit pod can collect and annotate logs for all containers on
+its node from a directory on the node.
 
 ```bash
 kubectl apply -f logging/fluent-bit-daemonset-permissions.yaml
@@ -100,23 +106,51 @@ In the following we will use some Fluentd tooling to process the logs on minikub
 
 ### Creation
 
-First we need to install the fluentd daemonset.
-It is configured in a way that it forwards the processed logs to a syslog
-destionation. So you might want to change the destination host/ip.
+First we need to install the Fluentd aggregator.
+It is configured in a way that it aggregates the processed logs from Fluent Bit
+and then outputs to multiple destinations. Fluentd is well suited to this task
+given its wide range of output plugins that provide support for many
+destinations that the logs can be sent to. We run it as a StatefulSet so that
+uptime can be ensured if pods are spread over multiple availability zones.
 
-```bash
-kubectl apply -f logging/fluentd-daemonset-permissions.yaml
-kubectl apply -f logging/fluentd-daemonset-syslog-minikube.yaml
-```
-
-Once this has been applied, you should see some log message at your syslog
-destination.
-
-You can use a demo app to see some application specific logs at the syslog
-destination:
+We use a custom image which adds some useful plugins to the base Fluentd image.
+One of which is the fluent-plugin-label-router so that we can route Fluentd
+records based on their Kubernetes metadata. This allows us to specify labels or
+some other Kubernetes metadata which can then be used to route specific records
+to a different destination. So we have all the `cluster-name:sample-pg-cluster`
+labeled pods (an instance of a PostgreSQL cluster) directed to stdout, this
+could be any destination. Additionally, we used the copy input plugin to
+duplicate the records so that we could have all logs in the cluster sent to a
+global destination, like Elasticsearch, instead of simply routing the
+PostgreSQL instance traffic to a single destination.
 
 ```shell
-kubectl apply -f logging/demo-app-counter.yaml
+cd Images/fluentd-aggregator/
+export IMG=localhost:5000/fluentd
+docker build -t $IMG .
+docker push $IMG
+cd ../..
+```
+
+```shell
+kubectl apply -f logging/fluentd-aggregator-configmap.yaml
+kubectl apply -f logging/fluentd-aggregator-service.yaml
+kubectl apply -f logging/fluentd-aggregator-statefulset.yaml
+```
+
+We will also deploy a PostgreSQL cluster and Opendistro for Elasticsearch so
+that we can see logs in a real cluster being sent to multiple destinations by
+the Fluentd aggregator. Follow the instructions from the [a8s-demo][a8s-demo]
+in order to get a cluster up and running using our PostgreSQL Operator.
+
+Once this has been applied, you should see some log messages that pertain to
+the PostgreSQL cluster in logs of the fluentd-aggregator in JSON format. You
+will also see logstash format logs which are being logged before being sent to
+Opendistro for Elasticsearch. You can differentiate between these based on the
+different formats.
+
+```shell
+kubectl -n a8s-system logs a8s-fluentd-aggregator-0
 ```
 
 ### Deletion
@@ -125,8 +159,9 @@ If you want to get rid of the whole daemon set setup, you can run the following
 commands:
 
 ```shell
-kubectl delete -f logging/fluentd-daemonset-minikube.yaml
-kubectl delete -f logging/fluentd-daemonset-permissions.yaml
+kubectl delete -f logging/fluentd-aggregator-configmap.yaml
+kubectl delete -f logging/fluentd-aggregator-service.yaml
+kubectl delete -f logging/fluentd-aggregator-statefulset.yaml
 ```
 
 If you used the demo app, delete it using the following commands:
@@ -149,3 +184,5 @@ Some general notes independent of Fluent Bit or Fluentd most of the time:
 - It looks quite easy to write your own fluentd image with the appropriate
   configuration(s) for our own framework/product. But would be great of course
   to use preexisting docker images as much as possible.
+
+[a8s-demo]: https://github.com/anynines/a8s-demo


### PR DESCRIPTION
Use the fluent-plugin-label-router plugin in a custom docker image in
order to route records based on their Kubernetes metadata. This provides
the capability to route to multiple destinations based on metadata such
as labels.