### PR TITLE
Fix for Elasicsearch log rejection

### DIFF
--- a/logging/fluent-bit-daemonset-configmap-forward-minikube.yaml
+++ b/logging/fluent-bit-daemonset-configmap-forward-minikube.yaml
@@ -29,7 +29,7 @@ data:
         Path              /var/log/containers/*.log
         Parser            docker
         DB                /var/log/flb_kube.db
-        Mem_Buf_Limit     5MB
+        Mem_Buf_Limit     512MB
         Skip_Long_Lines   On
         Refresh_Interval  10
 

--- a/logging/fluentd-aggregator-configmap.yaml
+++ b/logging/fluentd-aggregator-configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 data:
   fluent.conf: |-
     <source>
-      type forward
+      @type forward
       bind 0.0.0.0
       port 24224
     </source>
@@ -20,43 +20,42 @@ data:
         </route>
       </store>
       <store>
-         @type elasticsearch
-         @id out_es
-         @log_level info
-         include_tag_key true
-         host a8s-opendistro-es-client-service.a8s-system.svc.cluster.local
-         port 9200
-         scheme 'http'
-         ssl_verify 'true'
-         ssl_version 'TLSv1_2'
-         user 'admin'
-         password 'admin'
-         reload_connections 'false'
-         reconnect_on_error 'true'
-         reload_on_failure 'true'
-         log_es_400_reason 'false'
-         logstash_prefix 'logstash'
-         logstash_dateformat '%Y.%m.%d'
-         logstash_format 'true'
-         index_name 'logstash'
-         target_index_key use_nil
-         type_name 'fluentd'
-         include_timestamp 'false'
-         request_timeout '5s'
-         application_name use_default
-         suppress_type_name 'true'
-         enable_ilm 'false'
-         ilm_policy_id use_default
-         ilm_policy use_default
-         ilm_policy_overwrite 'false'
-         <buffer>
-           flush_thread_count '8'
-           flush_interval '5s'
-           chunk_limit_size '2M'
-           queue_limit_length '32'
-           retry_max_interval '30'
-           retry_forever true
-         </buffer>
+        @type elasticsearch
+        @id out_es
+        include_tag_key true
+        host a8s-opendistro-es-client-service.a8s-system.svc.cluster.local
+        port 9200
+        scheme 'http'
+        ssl_verify 'true'
+        ssl_version 'TLSv1_2'
+        user 'admin'
+        password 'admin'
+        reload_connections 'false'
+        reconnect_on_error 'true'
+        reload_on_failure 'true'
+        log_es_400_reason 'false'
+        logstash_prefix 'logstash'
+        logstash_dateformat '%Y.%m.%d'
+        logstash_format 'true'
+        index_name 'logstash'
+        target_index_key use_nil
+        type_name 'fluentd'
+        include_timestamp 'false'
+        request_timeout '5s'
+        application_name use_default
+        suppress_type_name 'true'
+        enable_ilm 'false'
+        ilm_policy_id use_default
+        ilm_policy use_default
+        ilm_policy_overwrite 'false'
+        <buffer>
+          flush_thread_count '8'
+          flush_interval '5s'
+          chunk_limit_size '2M'
+          queue_limit_length '32'
+          retry_max_interval '30'
+          retry_forever true
+        </buffer>
       </store>
     </match>
 

--- a/logging/fluentd-aggregator-statefulset.yaml
+++ b/logging/fluentd-aggregator-statefulset.yaml
@@ -24,16 +24,6 @@ spec:
       containers:
       - image: "localhost:5000/fluentd"
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          failureThreshold: 10
-          httpGet:
-            path: /fluent.healthcheck?json=%7B%22ping%22%3A+%22pong%22%7D
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 15
-          periodSeconds: 30
-          successThreshold: 1
-          timeoutSeconds: 1
         name: fluentd-aggregator
         ports:
         - containerPort: 9880

--- a/opendistro/a8s-opendistro-es-client-deployment.yaml
+++ b/opendistro/a8s-opendistro-es-client-deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: a8s-opendistro-es
     release: a8s
     role: client
   name: a8s-opendistro-es-client
@@ -13,7 +12,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app: a8s-opendistro-es
       release: a8s
       role: client
   strategy:
@@ -24,7 +22,6 @@ spec:
   template:
     metadata:
       labels:
-        app: a8s-opendistro-es
         release: a8s
         role: client
     spec:

--- a/opendistro/a8s-opendistro-es-client-service.yaml
+++ b/opendistro/a8s-opendistro-es-client-service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: a8s-opendistro-es
     release: a8s
     role: client
   name: a8s-opendistro-es-client-service

--- a/opendistro/a8s-opendistro-es-data-service.yaml
+++ b/opendistro/a8s-opendistro-es-data-service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: a8s-opendistro-es
     release: a8s
     role: data
   name: a8s-opendistro-es-data-svc

--- a/opendistro/a8s-opendistro-es-data-statefulset.yaml
+++ b/opendistro/a8s-opendistro-es-data-statefulset.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
-    app: a8s-opendistro-es
     release: a8s
     role: data
   name: a8s-opendistro-es-data
@@ -13,14 +12,12 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app: a8s-opendistro-es
       release: a8s
       role: data
   serviceName: a8s-opendistro-es-data-svc
   template:
     metadata:
       labels:
-        app: a8s-opendistro-es
         release: a8s
         role: data
     spec:

--- a/opendistro/a8s-opendistro-es-discovery-service.yaml
+++ b/opendistro/a8s-opendistro-es-discovery-service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: a8s-opendistro-es
     release: a8s
     role: master
   name: a8s-opendistro-es-discovery

--- a/opendistro/a8s-opendistro-es-es-config.yaml
+++ b/opendistro/a8s-opendistro-es-es-config.yaml
@@ -5,7 +5,6 @@ data:
 kind: Secret
 metadata:
   labels:
-    app: a8s-opendistro-es
     release: a8s
   name: a8s-opendistro-es-es-config
   namespace: a8s-system

--- a/opendistro/a8s-opendistro-es-es-serviceaccount.yaml
+++ b/opendistro/a8s-opendistro-es-es-serviceaccount.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: a8s-opendistro-es
     release: a8s
   name: a8s-opendistro-es-es
   namespace: a8s-system

--- a/opendistro/a8s-opendistro-es-kibana-config.yaml
+++ b/opendistro/a8s-opendistro-es-kibana-config.yaml
@@ -4,7 +4,6 @@ data:
 kind: Secret
 metadata:
   labels:
-    app: a8s-opendistro-es
     release: a8s
   name: a8s-opendistro-es-kibana-config
   namespace: a8s-system

--- a/opendistro/a8s-opendistro-es-kibana-deployment.yaml
+++ b/opendistro/a8s-opendistro-es-kibana-deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: a8s-opendistro-es
     release: a8s
     role: kibana
   name: a8s-opendistro-es-kibana
@@ -13,7 +12,6 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app: a8s-opendistro-es
       release: a8s
       role: kibana
   strategy:
@@ -24,7 +22,6 @@ spec:
   template:
     metadata:
       labels:
-        app: a8s-opendistro-es
         release: a8s
         role: kibana
     spec:

--- a/opendistro/a8s-opendistro-es-kibana-service.yaml
+++ b/opendistro/a8s-opendistro-es-kibana-service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: a8s-opendistro-es
     release: a8s
     role: kibana
   name: a8s-opendistro-es-kibana-svc

--- a/opendistro/a8s-opendistro-es-kibana-serviceaccount.yaml
+++ b/opendistro/a8s-opendistro-es-kibana-serviceaccount.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: a8s-opendistro-es
     release: a8s
   name: a8s-opendistro-es-kibana
   namespace: a8s-system

--- a/opendistro/a8s-opendistro-es-master-statefulset.yaml
+++ b/opendistro/a8s-opendistro-es-master-statefulset.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
-    app: a8s-opendistro-es
     release: a8s
     role: master
   name: a8s-opendistro-es-master
@@ -13,14 +12,12 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app: a8s-opendistro-es
       release: a8s
       role: master
   serviceName: a8s-opendistro-es-discovery
   template:
     metadata:
       labels:
-        app: a8s-opendistro-es
         release: a8s
         role: master
     spec:

--- a/operational-models/dashboard/logging-model.md
+++ b/operational-models/dashboard/logging-model.md
@@ -47,6 +47,10 @@ Kibana is a window into Elasticsearch. It provides a browser-based analytics
 and search dashboard. We deploy it as a Kubernetes [Deployment][deployment]
 since we don't require storage for Kibana.
 
+### Warning
+- Elasticsearch rejects logs from Fluentd that originate from pods with the
+  label `app`.
+
 [namespace]: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
 [service]: https://kubernetes.io/docs/concepts/services-networking/service/
 [statefulSet]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/


### PR DESCRIPTION
Elasticsearch rejected logs from Fluentd if the logs originated from
from pods that contained the `app` label. Some other smaller bugs
were addressed to increase robustness: 
* Mem_Buf_Limit for fluent-bit increased from 5MB to 512MB since the
  limit was being reached.
* Removal of liveness probe on Fluentd aggregator statefulSet since
  pods would receive SIGKILL unnecessarily.