### PR TITLE
Revert "Adjust prometheus configmap to scrape pg metrics"

### DIFF
--- a/deploy/a8s/postgresql-operator.yaml
+++ b/deploy/a8s/postgresql-operator.yaml
@@ -515,7 +515,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: "c4aeb71c-dd2a-4e6e-9385-1c3bb839307c.de.a9s.eu/a8s/postgresql-controller:v0.5.0"
+        image: "c4aeb71c-dd2a-4e6e-9385-1c3bb839307c.de.a9s.eu/a8s/postgresql-controller:0.4.0"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/deploy/metrics/collection-infrastructure/prometheus-configmap.yaml
+++ b/deploy/metrics/collection-infrastructure/prometheus-configmap.yaml
@@ -40,36 +40,6 @@ data:
         - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
           action: keep
           regex: true
-        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port]
-          action: keep
-          regex: 8443
-        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-          action: replace
-          target_label: __metrics_path__
-          regex: (.+)
-        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
-          action: replace
-          regex: ([^:]+)(?::\d+)?;(\d+)
-          replacement: $1:$2
-          target_label: __address__
-        - action: labelmap
-          regex: __meta_kubernetes_pod_label_(.+)
-        - source_labels: [__meta_kubernetes_namespace]
-          action: replace
-          target_label: kubernetes_namespace
-        - source_labels: [__meta_kubernetes_pod_name]
-          action: replace
-          target_label: kubernetes_pod_name
-      - job_name: 'postgres-metrics'
-        kubernetes_sd_configs:
-        - role: pod
-        relabel_configs:
-        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
-          action: keep
-          regex: true
-        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port]
-          action: keep
-          regex: 9187
         - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
           action: replace
           target_label: __metrics_path__


### PR DESCRIPTION
Revert anynines/a8s-deployment#11 because it breaks the ability to perform restores from backups for PostgreSQL.
More precisely, the bug is caused by the fact that the PR uses a new version of the PostgreSQL operator (`v.0.5.0`) that creates PostgreSQL instance nodes with a Prometheus metrics exporter as a sidecar. The sidecar keeps long-running connections to the databases to be restored, but a database can't be restored if there's an open connection to it.