### PR TITLE
Pull OpenSearch Dashboards and FluentD from ECR public registry

### DIFF
--- a/deploy/logging/collection-infrastructure/fluentd-aggregator.yaml
+++ b/deploy/logging/collection-infrastructure/fluentd-aggregator.yaml
@@ -51,7 +51,7 @@ spec:
         a8s.anynines/logging: "true"
     spec:
       containers:
-      - image: "c4aeb71c-dd2a-4e6e-9385-1c3bb839307c.de.a9s.eu/a8s/fluentd:0.1.0"
+      - image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/fluentd:v1.12.3-1.0-1.0.0
         imagePullPolicy: IfNotPresent
         name: fluentd-aggregator
         ports:

--- a/deploy/logging/dashboard/opensearch-dashboards.yaml
+++ b/deploy/logging/dashboard/opensearch-dashboards.yaml
@@ -77,7 +77,7 @@ spec:
     spec:
       containers:
       - name: a8s-opensearch-dashboards
-        image: c4aeb71c-dd2a-4e6e-9385-1c3bb839307c.de.a9s.eu/a8s/opensearch-dashboards:1.0.1
+        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/opensearch-dashboards:v1.0.1-1.0.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 5601


### PR DESCRIPTION
Make the OpenSearch Dashboards dashboard and FluentD log aggregator pull their container images from a8s public ECR registry rather than Harbor. This is done because the a8s team has decided to use the public ECR registry to store container images (until our own Harbor product becomes stable enough).