### PR TITLE
Bump backup manager version to make S3 bucket used for backups configurable

### DIFF
--- a/deploy/a8s/backup-manager.yaml
+++ b/deploy/a8s/backup-manager.yaml
@@ -452,7 +452,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: "c4aeb71c-dd2a-4e6e-9385-1c3bb839307c.de.a9s.eu/a8s/a8s-backup-manager:0.4.1"
+        image: "public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/backup-manager:v0.4.0"
         env:
         - name: systemNamespace
           valueFrom:

--- a/docs/platform_operators.md
+++ b/docs/platform_operators.md
@@ -32,9 +32,6 @@ a8s supports taking backups of data service instances (DSIs). Currently, the bac
 an AWS S3 bucket, so before installing a8s **you must create an AWS S3 bucket that a8s will use to
 store backups** ([here][s3-bucket-creation] is the official S3 documentation).
 
-> :warning: Currently Restores from Backups work only if the S3 bucket is called `a8s-shared-backups`
-(we hope to fix this soon and allow you to choose the name you want). Since bucket names have to be unique across an AWS partition, you will most likely have to use our bucket.
-
 Then, create an access key and secret key for the bucket. This is the key the a8s control plane
 will use to interact with the bucket.
 


### PR DESCRIPTION
This PR updates a8s-deployment to make it aware of https://github.com/anynines/a8s-backup-manager/pull/30 .