### PR TITLE
Fix app label bug

### DIFF
--- a/deploy/logging/collection-infrastructure/config/fluent.conf
+++ b/deploy/logging/collection-infrastructure/config/fluent.conf
@@ -4,6 +4,11 @@
     port 24224
 </source>
 
+<filter **>
+  @type rename_key
+  rename_rule1 ^app$ app.kubernetes.io/name
+</filter>
+
 <match **>
     @type copy
     <store>

--- a/docs/application_developers.md
+++ b/docs/application_developers.md
@@ -230,6 +230,11 @@ kubectl delete recovery <recovery-name>
 
 ### Visualize the Logs of the PostgreSQL Instance
 
+Application developers should be aware that all pods with the label field `app`
+will be adjusted within OpenSearch to have the label `app.kubernetes.io/name`.
+This pattern conforms with the [recommended labels][common-labels] expressed
+officially in the Kubernetes documentation.
+
 When installing the a8s platform, the platform operator had the option to install components to
 collect and visualize the logs of the data service instances (as shown in section
 [(Optional) Install the Logging Infrastructure](/docs/platform_operators.md#optional-install-the-logging-infrastructure)).
@@ -347,3 +352,4 @@ that are scraped by the Prometheus instance.
 [mount-secret-in-volume]: https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod
 [kubernetes-ingress]: https://kubernetes.io/docs/concepts/services-networking/ingress/
 [kubernetes-port-forwarding]: https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/
+[common-labels]: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/


### PR DESCRIPTION
OpenSearch rejects logs from the Fluentd aggregator if logs originate
from pods containing the `app` field as a label. This fix uses a filter
pvoided by the `fluent-plugin-rename-key` plugin to rename any labels
using the `app` label to the recommended `app.kubernetes.io/name` label.