### PR TITLE
Bump FluentD container image version

### DIFF
--- a/deploy/logging/collection-infrastructure/fluentd-aggregator.yaml
+++ b/deploy/logging/collection-infrastructure/fluentd-aggregator.yaml
@@ -51,7 +51,7 @@ spec:
         a8s.anynines/logging: "true"
     spec:
       containers:
-      - image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/fluentd:v1.12.3-1.0-1.0.0
+      - image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/fluentd:v1.12.3-1.0-1.1.0
         imagePullPolicy: IfNotPresent
         name: fluentd-aggregator
         ports:


### PR DESCRIPTION
Bump FluentD container image version to a more recent version that includes the rename_key plugin (which is used by the FluentD config we use).