### PR TITLE
Add github workflow to bump container images nightly

### DIFF
--- a/.github/workflows/update-container-images.yaml
+++ b/.github/workflows/update-container-images.yaml
@@ -1,0 +1,95 @@
+name: Update container images
+
+on:
+  schedule:
+    # Update the container images every morning at 05:00 (or 04:00, depending on whether daylight
+    # savings time is on or not) CEST; skip Saturdays and Sundays. The hour in the expression below
+    # is 03 because the timezone is in UTC.
+    - cron: '15 15 * * 1-5'
+
+jobs:
+  get-branches-to-update-container-images:
+    runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ steps.get-branches-to-update-container-images.outputs.branches }}
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v2
+        with:
+          # Use fetch-depth of 0 to fetch all history for all branches. Otherwise, only the tip of
+          # the default branch is fetched while this job needs to get all branches whose name
+          # matches a certain pattern.
+          fetch-depth: '0'
+      - name: Get branches to update container images
+        id: get-branches-to-update-container-images
+        run: |
+          branches_to_update_container_images=$(git -P branch --remotes --list 'origin/update_container_images_*') && \
+          echo "::set-output name=branches::${branches_to_update_container_images}"
+
+  update-container-images:
+    runs-on: ubuntu-latest
+    needs: get-branches-to-update-container-images
+    # Proceed to create a new branch and a PR to update container images (if there are any updates)
+    # if and only if there aren't already open branches to do that. The idea is that if there's an
+    # already open branch it should be merged first, for example to avoid cumulating branches during
+    # holidays, when no one will merge the PRs from said branches.
+    if: ${{ needs.get-branches-to-update-container-images.outputs.branches == '' }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.A8S_ECR_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.A8S_ECR_AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-central-1
+      - name: Store most recent version tag for each image
+        env:
+          REPO_NAMESPACE: a9s-ds-for-k8s/dev
+          IMAGES: "postgresql-operator service-binding-controller backup-manager fluentd opensearch-dashboards"
+        run: |
+          VERSIONED_IMAGES=""
+          for IMG in ${IMAGES[*]}
+          do
+            read NEW_VERSION <<< $(aws ecr-public describe-images \
+              --repository-name $REPO_NAMESPACE/$IMG \
+              --query 'sort_by(imageDetails, &imagePushedAt)[-1].imageTags[0]' \
+              --output text \
+              --region us-east-1)
+            if [ -z "${NEW_VERSION}" ] || [ "${NEW_VERSION}" == "None" ]; then
+              echo "Found no images in repo $REPO_NAMESPACE/$IMG; should never happen"
+              exit 1
+            fi
+            VERSIONED_IMAGES+="$IMG:$NEW_VERSION "
+          done
+          echo "VERSIONED_IMAGES=$VERSIONED_IMAGES" >> $GITHUB_ENV
+      - name: Store current date to use it as a suffix for the name of the branch to update images
+        id: get-date
+        run: echo "::set-output name=date::$(date +'%d_%m_%Y')"
+      - name: Checkout this repo
+        uses: actions/checkout@v2
+      - name: Update images if needed
+        run: |
+          git config user.name github-actions && \
+          git config user.email github-actions@github.com && \
+          chmod +x automation-scripts/update-container-images.sh && \
+          automation-scripts/update-container-images.sh "${{ env.VERSIONED_IMAGES }}"
+      - name: Create pull request if at least one image was updated
+        uses: peter-evans/create-pull-request@v3
+        with:
+          delete-branch: true
+          branch: 'update_container_images_${{ steps.get-date.outputs.date }}'
+          # Strictly speaking this is not needed since 'develop' is picked as the base branch by
+          # default when the action runs in github. But when testing the action locally on a
+          # different branch that branch is picked instead, while we still want 'develop' as base.
+          # So we set the parameter explicitly to ease local testing.
+          base: 'develop'
+          author: 'github-actions <github-actions@github.com>'
+          title: 'Update Container Images'
+          body: |
+            Automated update of container images to new available versions.
+            
+            For the a8s core components (postgresql operator, backup manager, service binding
+            controller), please check that a github release with the same name as the new version
+            exists in the repo of the relevant component. If that's not the case, it's likely
+            because the new image was pushed spuriously during testing by a developer who forgot to
+            delete it, so it's not a legitimate image and should NOT be used; remove the
+            corresponding commit from this PR and delete the image from ECR.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 access-key-id
 secret-access-key
 backup-store-config.yaml
+
+# Ignore files under workflow/ dir created by https://github.com/nektos/act (act) , the tool that we
+# use to test github actions locally. Needed because in this repo we have github actions that commit
+# changes and open PRs, and we don't want the files created by act when testing locally to be
+# committed.
+workflow/

--- a/automation-scripts/update-container-images.sh
+++ b/automation-scripts/update-container-images.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This script is invoked by a github action that runs within an ubuntu VM. But it might be invoked
+# manually by developers on their macos work laptop for testing. This is problematic because the
+# script uses "sed", and sed's syntax is different between linux and macos. So we assume that the
+# developer testing from macos also has "gsed" (the macos version of linux's sed; i.e. gsed on
+# macos has the same syntax as sed on linux) installed on his machine. The following if selects
+# gsed as the command to use if this script runs on macos, while picks "sed" otherwise (it assumes
+# that if the OS isn't macos then it's linux).
+SED="sed"
+if [[ $OSTYPE == 'darwin'* ]]
+then
+    SED="gsed"
+fi
+readonly SED
+
+# new_version_is_newer assumes that the two versions that it receives as arguments are in the
+# same format, and will fail (in some cases, silently) if that's not the case.
+new_version_is_newer () {
+    # Replace ".", "-" and "v" with " " in the versions so that it becomes easier to compare each
+    # version token from the new version to the corresponding token from the current version. What
+    # do I mean by token? For example I see a semver 2 version as:
+    # v<major-token>.<minor-token>.<patch-token>.
+    local NEW_VERSION=$($SED "s/[\.v-]/ /g" <<< $1)
+    local CURRENT_VERSION=$($SED "s/[\.v-]/ /g" <<< $2)
+
+    # From a string containing all the tokens of a version to an array where each item represents
+    # a single token (in descending order of priority), to ease comparison between new and current
+    # version.
+    local NEW_VERSION_TOKENS=( $NEW_VERSION )
+    local CURRENT_VERSION_TOKENS=( $CURRENT_VERSION )
+
+    # Now, compare each token between new and current version in descending order of priority, to
+    # establish which version is newer.
+    for i in "${!NEW_VERSION_TOKENS[@]}"
+    do
+        if [ ${NEW_VERSION_TOKENS[$i]} -gt ${CURRENT_VERSION_TOKENS[$i]} ]
+        then
+            return 0
+        fi
+        if [ ${NEW_VERSION_TOKENS[$i]} -lt ${CURRENT_VERSION_TOKENS[$i]} ]
+        then
+            return 1
+        fi
+    done
+
+    return 1
+}
+
+ensure_image_is_fresh_and_commit () {
+    local IMG=$1
+    local NEW_VERSION=$2
+    local MANIFEST=$3
+
+    # Prepare sed expression to extract the current version of the image from its yaml manifest.
+    # The regexp isn't strict: it matches the image version, but it'll match also incorrect
+    # formats. I started with an extremely precise regexp but it was overly long and complex, so I
+    # opted for allowing some incorrect formats for simplicity's sake. Since we control the parsed
+    # manifests we can have strong guarantees that the versions will be in the right formats, so
+    # there should be no issues. Notice that the group that captures the version matches more than
+    # just semver 2 versions, because we have some images (fluentd and opensearch-dashboards) that
+    # don't follow semver 2.
+    local GET_VERSION_SED_CMD="s/^[[:space:]-]\{1,\}image:[[:space:]].\{1,\}\/$IMG:\(v[\.[:digit:]-]\{1,\}\)\"\{0,1\}$/\1/p"
+    local CURRENT_VERSION=$($SED -n $GET_VERSION_SED_CMD $MANIFEST)
+
+    if new_version_is_newer "$NEW_VERSION" "$CURRENT_VERSION"
+    then
+        # Prepare sed expression to update the version of the image in its yaml manifest. The regexp
+        # isn't strict: it matches the image version, but it'll match also incorrect formats. I
+        # started with an extremely precise regexp but it was overly long and complex, so I opted
+        # for allowing some incorrect formats for simplicity's sake. Since we control the parsed
+        # manifests we can have strong guarantees that the versions will be in the right formats, so
+        # there should be no issues. Notice that the group that captures the version matches more
+        # than just semver 2 versions, because we have some images (fluentd and
+        # opensearch-dashboards) that don't follow semver 2.
+        local UPDATE_VERSION_SED_CMD="s/^\([[:space:]-]\{1,\}image:[[:space:]].\{1,\}\/$IMG:\)v[\.[:digit:]-]\{1,\}\(\"\{0,1\}\)$/\1$NEW_VERSION\2/"
+        $SED -i $UPDATE_VERSION_SED_CMD $MANIFEST
+        git add "$MANIFEST"
+        git commit -m "Bump $IMG to $NEW_VERSION"
+    else
+        echo "Current version of $IMG is $CURRENT_VERSION, most recent version found is $NEW_VERSION, no update needed"
+    fi
+}
+
+main () {
+    local VERSIONED_IMGS="$1"
+    for VERSIONED_IMG in $VERSIONED_IMGS
+    do
+        # Extract image name and version as separate variables
+        local IMG=$(echo $VERSIONED_IMG | cut -d ':' -f 1)
+        local NEW_VERSION=$(echo $VERSIONED_IMG | cut -d ':' -f 2)
+
+        # Each image needs to be updated in a yaml manifest with an ad-hoc name (i.e. there's no
+        # regular pattern), so we have to branch and manually build the manifest name differently
+        # for each component.
+        if [[ "$IMG" == "fluentd" ]]
+        then
+            local MANIFEST="deploy/logging/collection-infrastructure/fluentd-aggregator.yaml"
+        elif [[ "$IMG" == "opensearch-dashboards" ]]
+        then
+            local MANIFEST="deploy/logging/dashboard/opensearch-dashboards.yaml"
+        else
+            local MANIFEST="deploy/a8s/$IMG.yaml"
+        fi
+
+        # If needed, update the image version in the relevant yaml manifests and commit each update
+        # individually to easily pinpoint which update broke things in case tests fail.
+        ensure_image_is_fresh_and_commit $IMG $NEW_VERSION $MANIFEST
+    done
+}
+
+main "$1"

--- a/deploy/a8s/backup-manager.yaml
+++ b/deploy/a8s/backup-manager.yaml
@@ -452,7 +452,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: "public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/backup-manager:v0.4.0"
+        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/backup-manager:v0.6.0
         env:
         - name: systemNamespace
           valueFrom:

--- a/deploy/a8s/service-binding-controller.yaml
+++ b/deploy/a8s/service-binding-controller.yaml
@@ -318,7 +318,7 @@ spec:
         - /manager
         - --postgresql-root-role=a9s_user
         - --postgresql-default-database=a9s_apps_default_db
-        image: "c4aeb71c-dd2a-4e6e-9385-1c3bb839307c.de.a9s.eu/a8s/service-binding-controller:0.2.0"
+        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/service-binding-controller:v0.4.0
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
This PR adds a Github action that checks nightly whether new images are available for some of the a8s components and updates the YAML manifests if so. More precisely, it does so for all components except:
- those whose images we don't own (prometheus, grafana and opensearch).
- the backup agent.

Components whose images we don't own are left out because the logic for retrieving their version would be substantially different than that for fetching the version of the core components, and is left as future work. The backup agent is also left out because we still don't have a canonical place where the image to use for it will reside (right now it's directly in the PG resource but we already agreed that soon we'll move it out somewhere else) - we leave that as a follow-up for when we have a definitive place where that will reside.

Notes for the tester, to test locally:
- To test locally, you'll need to install [act](https://github.com/nektos/act) at version at least 0.25 (older versions have a bug affecting the interaction with the github API that causes things to break).
- In the job `update-container-images`, you'll need to add a first step that installs the aws-cli (it's already present on the default ubuntu runner that github uses, but not in the lightweight runner that `act` uses):
```
- id: install-aws-cli
  uses: unfor19/install-aws-cli-action@v1
```
- When you test via act, you'll look like the author of the PR that updates the images. I verified that this is not the case when the action is run "for real" by github by testing on a private, dummy repo (`github-actions` appears as the author in that case).
- The command I used to test from my `a8s-deployment` local clone is: 
`act schedule  -s A8S_ECR_AWS_ACCESS_KEY_ID=<access key ID> -s A8S_ECR_AWS_SECRET_ACCESS_KEY=<secret access key>  -s GITHUB_TOKEN=<github token>`
`<github token>` is your Github access token, the aws key is the one called `a8s ECR Pusher key` in the `a9s-data-services` 1password vault.
- If you're testing on macos, you'll need to have `gsed` installed, but not as the default `sed` command. i.e., you should still invoke it via `gsed` rather than `sed`.

The logic that checks which images need to be updated and commit the changes is in a dedicated script under `automation-scripts`, that you can test manually without running the whole action. However, if you do that on macos you'll need to have `gsed` installed, but not as the default `sed` command. i.e., you should still invoke it via `gsed` rather than `sed` (the reason is essentially that sed on macos and sed on ubuntu are incompatible and the action runs on ubuntu, so the script uses `sed` if it's on ubuntu, `gsed` if it's on macos).


Edit 1:
Two notes:

1. This PR also updates the service binding controller and backup manager manifests to make use of the images in ECR (before they were still using Harbor). The reason is that the logic that updates the manifests only changes the version of the image, not the repo it comes from. So if we didn't do that change we would still be using Harbor (and the new images wouldn't be there). We could tweak that logic to also make it overwrite the image registry/repo to always be ECR, but IMO it's not worth it: it's something that needs to be done only once (the first time the workflow runs) and complicates the logic, hence the manual change.
2. The versions of the service binding controller and backup manager added by this PR are NOT the most recent ones. The reason is that since you don't really know whether github actions work until they are actually merged, after local testing is successful you can merge this PR, and wait the next day to see if a PR to update the images has been successfully created (you can consider this the last testing step). Only then move the ticket to DONE (or fix things before moving it to DONE).
