### PR TITLE
Fix schedule of automated image update

### DIFF
--- a/.github/workflows/update-container-images.yaml
+++ b/.github/workflows/update-container-images.yaml
@@ -5,7 +5,7 @@ on:
     # Update the container images every morning at 05:00 (or 04:00, depending on whether daylight
     # savings time is on or not) CEST; skip Saturdays and Sundays. The hour in the expression below
     # is 03 because the timezone is in UTC.
-    - cron: '15 15 * * 1-5'
+    - cron: '0 3 * * 1-5'
 
 jobs:
   get-branches-to-update-container-images:


### PR DESCRIPTION
A previous PR merged a commit to automatically update container images every night. That commit made the automatic update run at a time convenient for testing, i.e., shortly after the time at which we merged the PR, so that we could verify that the update was successful. This commit restores the schedule to its normal value (late night).