### PR TITLE
Use a unique namespace for the testing namespace [DO NOT MERGE]

### DIFF
--- a/test/integration/backup/backup_suite_test.go
+++ b/test/integration/backup/backup_suite_test.go
@@ -37,17 +37,22 @@ var _ = BeforeSuite(func() {
 	kubeconfigPath, instanceNamePrefix, dataservice, testingNamespace =
 		framework.ConfigToVars(config)
 
+	// testingNamespace needs to be unique so that all test suites can be run without deleting
+	// the namespace before the new suite begins. In this case the testingNamespace could be
+	// terminating while the next suite starts causing the tests to fail.
+	testingNamespace = framework.UniqueName(testingNamespace, suffixLength)
+
 	// Create kubernetes client for interacting with the Kubernetes API
 	k8sClient, err = dsi.NewK8sClient(dataservice, kubeconfigPath)
 	Expect(err).To(BeNil(),
 		fmt.Sprintf("error creating Kubernetes client for dataservice %s", dataservice))
 
-	Expect(namespace.CreateIfNotExists(ctx, testingNamespace, k8sClient)).
+	Expect(namespace.Create(ctx, testingNamespace, k8sClient)).
 		To(Succeed(), "failed to create testing namespace")
 })
 
 var _ = AfterSuite(func() {
-	Expect(namespace.DeleteIfAllowed(ctx, testingNamespace, k8sClient)).
+	Expect(namespace.Delete(ctx, testingNamespace, k8sClient)).
 		To(Succeed(), "failed to delete testing namespace")
 	cancel()
 })

--- a/test/integration/framework/namespace/namespace.go
+++ b/test/integration/framework/namespace/namespace.go
@@ -10,7 +10,7 @@ import (
 	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func CreateIfNotExists(ctx context.Context,
+func Create(ctx context.Context,
 	testingNamespace string,
 	c runtimeClient.Client) error {
 
@@ -29,7 +29,7 @@ func CreateIfNotExists(ctx context.Context,
 	return err
 }
 
-func DeleteIfAllowed(ctx context.Context,
+func Delete(ctx context.Context,
 	testingNamespace string,
 	c runtimeClient.Client) error {
 

--- a/test/integration/postgresql/postgresql_suite_test.go
+++ b/test/integration/postgresql/postgresql_suite_test.go
@@ -37,17 +37,22 @@ var _ = BeforeSuite(func() {
 	kubeconfigPath, instanceNamePrefix, dataservice, testingNamespace =
 		framework.ConfigToVars(config)
 
+	// testingNamespace needs to be unique so that all test suites can be run without deleting
+	// the namespace before the new suite begins. In this case the testingNamespace could be
+	// terminating while the next suite starts causing the tests to fail.
+	testingNamespace = framework.UniqueName(testingNamespace, suffixLength)
+
 	// Create Kubernetes client for interacting with the Kubernetes API
 	k8sClient, err = dsi.NewK8sClient(dataservice, kubeconfigPath)
 	Expect(err).To(BeNil(),
 		fmt.Sprintf("error creating Kubernetes client for dataservice %s", dataservice))
 
-	Expect(namespace.CreateIfNotExists(ctx, testingNamespace, k8sClient)).
+	Expect(namespace.Create(ctx, testingNamespace, k8sClient)).
 		To(Succeed(), "failed to create testing namespace")
 })
 
 var _ = AfterSuite(func() {
-	Expect(namespace.DeleteIfAllowed(ctx, testingNamespace, k8sClient)).
+	Expect(namespace.Delete(ctx, testingNamespace, k8sClient)).
 		To(Succeed(), "failed to delete testing namespace")
 	cancel()
 })

--- a/test/integration/servicebinding/servicebinding_suite_test.go
+++ b/test/integration/servicebinding/servicebinding_suite_test.go
@@ -39,17 +39,22 @@ var _ = BeforeSuite(func() {
 	kubeconfigPath, instanceNamePrefix, dataservice, testingNamespace =
 		framework.ConfigToVars(config)
 
+	// testingNamespace needs to be unique so that all test suites can be run without deleting
+	// the namespace before the new suite begins. In this case the testingNamespace could be
+	// terminating while the next suite starts causing the tests to fail.
+	testingNamespace = framework.UniqueName(testingNamespace, suffixLength)
+
 	// Create kubernetes client for interacting with the Kubernetes API
 	k8sClient, err = dsi.NewK8sClient(dataservice, kubeconfigPath)
 	Expect(err).To(BeNil(),
 		fmt.Sprintf("error creating Kubernetes client for dataservice %s", dataservice))
 
-	Expect(namespace.CreateIfNotExists(ctx, testingNamespace, k8sClient)).
+	Expect(namespace.Create(ctx, testingNamespace, k8sClient)).
 		To(Succeed(), "failed to create testing namespace")
 })
 
 var _ = AfterSuite(func() {
-	Expect(namespace.DeleteIfAllowed(ctx, testingNamespace, k8sClient)).
+	Expect(namespace.Delete(ctx, testingNamespace, k8sClient)).
 		To(Succeed(), "failed to delete testing namespace")
 
 	cancel()


### PR DESCRIPTION
Our test suites delete the testing namespace once they complete.
When running all test suites at once with a testing namespace set the
the second test suite will fail due to the testing namespace being in a
terminating state.

A quick fix is to add a unique suffix to testing namespace so that this
issue does not occur. This may not be what we want since it changes
expectations the user or automation (LATR) may have about the testing
namespace they believe to be targeting.

Some other approaches that come to mind:
1. Have the user or LATR delete the namespace after use. And make it so
   the testing framework does not do this. This takes responsibility away
   from individual test suites to delete the namespace after use.
2. Provide a switch via environmental variable to enable or disable
   deleting namespace at the end of the suite. This in a sense gives us
   both options.
3. Simply create a unique namespace by adding a random suffix to the
   provided testing namespace name. That is what this PR currently does.
4. Make it optional whether we add a random suffix via environtal
   variable.
5. Dynamically Use a random suffix only if the namespace is in a
   terminating state.