### PR TITLE
Bump backup-manager version and RBAC

### DIFF
--- a/deploy/a8s/backup-manager.yaml
+++ b/deploy/a8s/backup-manager.yaml
@@ -230,6 +230,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - list
@@ -452,7 +459,7 @@ spec:
         - --leader-elect
         command:
         - a8s-backup-manager
-        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/backup-manager:v0.13.0
+        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/backup-manager:v0.15.0
         env:
         - name: systemNamespace
           valueFrom:


### PR DESCRIPTION
Update backup-manager image and RBAC in order to provide
events for associated resources for increased observability in the
cluster.

# Short Description
Update  backup-manager to v0.15.0 and update RBAC for emitting events
# Details
https://github.com/anynines/a8s-backup-manager/pull/41
# Checks
- [x] ~~Documentation has been adjusted~~
- [x] ~~Architectural decisions have been documented~~
- [x] ~~Changelog has been updated~~
- [x] Manifests are updated
- [x] Commit message adheres to our [guideline](https://anynines.atlassian.net/wiki/spaces/DS/pages/2423193626/Version+Control+Workflow)
