### PR TITLE
Fix backup config path in documentation

### DIFF
--- a/docs/platform-operators/installing_framework.md
+++ b/docs/platform-operators/installing_framework.md
@@ -64,7 +64,7 @@ echo <bucket-secret-access-key> > deploy/a8s/secret-access-key # create file tha
 
 echo <encryption password> > deploy/a8s/encryption-password # create file that stores password for backup encryption
 
-cp deploy/a8s/backup-store-config.yaml.template config/backup-store-config.yaml # create file with other information about the bucket
+cp deploy/a8s/backup-store-config.yaml.template deploy/a8s/backup-store-config.yaml # create file with other information about the bucket
 ```
 
 Then, use an editor to open `deploy/a8s/backup-store-config.yaml` and replace the value:


### PR DESCRIPTION
Fix the documentation which contains a wrong destination path when
copying the backup-store-config.yaml.template to
backup-store-config.yaml.

# Short Description
_Please provide a brief summary of your changes_
# Details

# Checks
- [x] Documentation has been adjusted
- [x] Architectural decisions have been documented
- [x] Changelog has been updated
- [x] Manifests are updated
- [x] Commit message adheres to our [guideline](https://anynines.atlassian.net/wiki/spaces/DS/pages/2423193626/Version+Control+Workflow)
