### PR TITLE
Add tests on tolerations to node taints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - max_locks_per_transaction PostgreSQL configuration property has been added
+- end-to-end tests on PostgreSQL tolerations to node taints.
 
 ### Fixed
 

--- a/test/integration/framework/dsi/dsi.go
+++ b/test/integration/framework/dsi/dsi.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -29,6 +30,14 @@ type Object interface {
 	ClusterStatus() string
 	runtimeClient.Object
 	GetClientObject() runtimeClient.Object
+}
+
+type TolerationsSetter interface {
+	SetTolerations(...corev1.Toleration)
+}
+
+type StatefulSetGetter interface {
+	StatefulSet(context.Context, runtimeClient.Client) (*appsv1.StatefulSet, error)
 }
 
 // This package does not use functional options like others in the framework since we need to
@@ -62,6 +71,9 @@ func newEmpty(ds string) (Object, error) {
 func supportedDataServices() string {
 	return "PostgreSQL"
 }
+
+// TODO: rather than having all these functions here, consider switching to an OOP approach where
+// each instance object exposes these functions for itself as methods.
 
 func WaitForReadiness(ctx context.Context, instance runtimeClient.Object, c runtimeClient.Client) {
 	var err error

--- a/test/integration/topology_awareness/nodes_tainter.go
+++ b/test/integration/topology_awareness/nodes_tainter.go
@@ -1,0 +1,145 @@
+package topology_awareness
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+// This file contains some utils to fiddle with K8s nodes taints. We initially tried using the
+// upstream utils in https://pkg.go.dev/k8s.io/kubernetes/pkg/util/taints . We gave up because
+// of this: https://github.com/kubernetes/kubernetes/issues/79384 .
+
+// TODO: Replace  stdlib log package. Either use what Ginkgo recommends or what we use in other
+// components (e.g. the controllers).
+
+var (
+	// Well known taints for master nodes, see
+	// https://kubernetes.io/docs/reference/labels-annotations-taints/.
+	// Tainting such nodes might result in a broken cluster should one of the
+	// control plane components fail during the test runs.
+	masterNodeTaintKeys = map[string]struct{}{
+		"node-role.kubernetes.io/master":        {},
+		"node-role.kubernetes.io/control-plane": {},
+	}
+)
+
+// TODO: Consider whether it's worth it to factor this out to a dedicated package
+type nodesTainter struct {
+	nodes corev1client.NodeInterface
+}
+
+func newNodesTainter(nodes corev1client.NodeInterface) nodesTainter {
+	return nodesTainter{nodes: nodes}
+}
+
+func (nt nodesTainter) taintAllNodes(ctx context.Context, t []corev1.Taint) error {
+	nodes, err := nt.nodes.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list all K8s nodes to taint: %w", err)
+	}
+
+	for _, n := range nodes.Items {
+		if hasMasterNodeTaints(n.Spec.Taints) {
+			// TODO: stop relying on std logging library, and fix logging all over the code that
+			// supports tests (either use what Ginkgo recommends or what we use in controllers).
+			log.Printf("Warning: Did not taint node %s as it has a well known master taint", n.Name)
+			continue
+		}
+		if len(n.Spec.Taints) > 0 {
+			log.Printf("Warning: Node %s already is tainted with taints %v. This might break the "+
+				"tolerations tests", n.Name, n.Spec.Taints)
+		}
+		if newTaints := nt.union(n.Spec.Taints, t); len(newTaints) != len(n.Spec.Taints) {
+			n.Spec.Taints = newTaints
+			if _, err := nt.nodes.Update(ctx, &n, metav1.UpdateOptions{}); err != nil {
+				return fmt.Errorf("update of node %s to add taints %v failed: %w", n.Name, t, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (nt nodesTainter) untaintAllNodes(ctx context.Context, t []corev1.Taint) error {
+	nodes, err := nt.nodes.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list all K8s nodes to untaint: %w", err)
+	}
+
+	for _, n := range nodes.Items {
+		if newTaints := nt.diff(n.Spec.Taints, t); len(newTaints) != len(n.Spec.Taints) {
+			n.Spec.Taints = newTaints
+			if _, err := nt.nodes.Update(ctx, &n, metav1.UpdateOptions{}); err != nil {
+				return fmt.Errorf("update of node %s to remove taints %v failed: %w", n.Name, t, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (nodesTainter) union(x, y []corev1.Taint) []corev1.Taint {
+	taintKeyToTaint := make(map[string]corev1.Taint, len(x)+len(y))
+
+	for _, t := range x {
+		taintKeyToTaint[t.Key] = t
+	}
+
+	for _, t1 := range y {
+		t2, keyAlreadyPresent := taintKeyToTaint[t1.Key]
+		if keyAlreadyPresent && (t1.Value != t2.Value || t1.Effect != t2.Effect) {
+			// TODO: return an error rather than panicing here - if we need to panic let the caller
+			// do that.
+			panic(fmt.Sprintf("can't taint node: found taint %s with a8s test key %s but "+
+				"(value, effect)=(%s, %s); (value, effect) must be equal to (%s, %s)", t2, t2.Key,
+				t2.Value, t2.Effect, t1.Value, t1.Effect))
+		}
+		taintKeyToTaint[t1.Key] = t1
+	}
+
+	union := make([]corev1.Taint, 0, len(taintKeyToTaint))
+	for _, t := range taintKeyToTaint {
+		union = append(union, t)
+	}
+	return union
+}
+
+func (nodesTainter) diff(x, y []corev1.Taint) []corev1.Taint {
+	taintKeyToTaint := make(map[string]corev1.Taint, len(x))
+
+	for _, t := range x {
+		taintKeyToTaint[t.Key] = t
+	}
+
+	for _, t1 := range y {
+		t2, foundKey := taintKeyToTaint[t1.Key]
+		if foundKey && (t1.Value != t2.Value || t1.Effect != t2.Effect) {
+			// TODO: return an error rather than panicing here - if we need to panic let the caller
+			// do that.
+			panic(fmt.Sprintf("can't untaint node: found taint %s with a8s test key %s but "+
+				"(value, effect)=(%s, %s); (value, effect) must be equal to (%s, %s)", t2, t2.Key,
+				t2.Value, t2.Effect, t1.Value, t1.Effect))
+		}
+		delete(taintKeyToTaint, t1.Key)
+	}
+
+	diff := make([]corev1.Taint, 0, len(taintKeyToTaint))
+	for _, t := range taintKeyToTaint {
+		diff = append(diff, t)
+	}
+	return diff
+}
+
+func hasMasterNodeTaints(taints []corev1.Taint) bool {
+	for _, t := range taints {
+		if _, found := masterNodeTaintKeys[t.Key]; found {
+			return true
+		}
+	}
+	return false
+}

--- a/test/integration/topology_awareness/object.go
+++ b/test/integration/topology_awareness/object.go
@@ -1,0 +1,29 @@
+package topology_awareness
+
+import (
+	"fmt"
+
+	"github.com/anynines/a8s-deployment/test/integration/framework/dsi"
+)
+
+type Object interface {
+	dsi.Object
+	dsi.StatefulSetGetter
+	dsi.TolerationsSetter
+}
+
+func newDSI(ds, namespace, name string, replicas int32) (Object, error) {
+	baseObj, err := dsi.New(ds, namespace, name, replicas)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert baseObj to a topology_awareness.Object
+	taObj, ok := baseObj.(Object)
+	if !ok {
+		return nil, fmt.Errorf("can't create topology-aware DSI for data service %s because "+
+			"the data service doesn't implement interface \"topology_awareness.Object\"", ds)
+	}
+
+	return taObj, nil
+}

--- a/test/integration/topology_awareness/topology_awareness_suite_test.go
+++ b/test/integration/topology_awareness/topology_awareness_suite_test.go
@@ -1,0 +1,66 @@
+package topology_awareness
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/anynines/a8s-deployment/test/integration/framework"
+	"github.com/anynines/a8s-deployment/test/integration/framework/dsi"
+	"github.com/anynines/a8s-deployment/test/integration/framework/namespace"
+)
+
+var (
+	ctx                                                               context.Context
+	cancel                                                            context.CancelFunc
+	testingNamespace, kubeconfigPath, dataservice, instanceNamePrefix string
+
+	k8sClient runtimeClient.Client
+	tainter   nodesTainter
+)
+
+func TestTopologyAwareness(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Topology Awareness Suite")
+}
+
+var _ = BeforeSuite(func() {
+	ctx, cancel = context.WithCancel(context.Background())
+
+	// Parse environmental variable configuration
+	config, err := framework.ParseEnv()
+	Expect(err).To(BeNil(), "failed to parse environmental variables as configuration")
+	kubeconfigPath, instanceNamePrefix, dataservice, testingNamespace =
+		framework.ConfigToVars(config)
+
+	// Create Kubernetes client for interacting with the Kubernetes API
+	k8sClient, err = dsi.NewK8sClient(dataservice, kubeconfigPath)
+	Expect(err).To(BeNil(),
+		fmt.Sprintf("error creating Kubernetes client for dataservice %s", dataservice))
+
+	Expect(namespace.CreateIfNotExists(ctx, testingNamespace, k8sClient)).
+		To(Succeed(), "failed to create testing namespace")
+
+	// Generate a convenience object for tainting K8s nodes
+	c, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	Expect(err).To(BeNil(),
+		"failed to create client config for nodes tainter from kubeconig "+kubeconfigPath)
+
+	cv1Client, err := corev1client.NewForConfig(c)
+	Expect(err).To(BeNil(),
+		fmt.Sprintf("failed to create client for nodes tainter from config %v", c))
+
+	tainter = newNodesTainter(cv1Client.Nodes())
+})
+
+var _ = AfterSuite(func() {
+	defer cancel()
+	Expect(namespace.DeleteIfAllowed(ctx, testingNamespace, k8sClient)).
+		To(Succeed(), "failed to delete testing namespace")
+})

--- a/test/integration/topology_awareness/topology_awareness_test.go
+++ b/test/integration/topology_awareness/topology_awareness_test.go
@@ -1,0 +1,440 @@
+package topology_awareness
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/anynines/a8s-deployment/test/integration/framework"
+	"github.com/anynines/a8s-deployment/test/integration/framework/dsi"
+	"github.com/anynines/a8s-deployment/test/integration/framework/secret"
+	"github.com/anynines/a8s-deployment/test/integration/framework/servicebinding"
+	sbv1alpha1 "github.com/anynines/a8s-service-binding-controller/api/v1alpha1"
+)
+
+// TODO: Test broken cases where the DSI has no tolerations: 1 taint - 0 tolerations;
+// 	     2 taints - 1 toleration; 1 taint - 1 toleration that doesn't match it.
+// TODO: Test removing tolerations from an existing DSI.
+// TODO: Test adding tolerations to an existing DSI.
+// TODO: Test horizontal scale up.
+// TODO: Test cases where only a subset of nodes is tainted.
+
+const (
+	suffixLength = 5
+
+	appsDefaultDB = "a9s_apps_default_db"
+
+	instancePort = 5432
+)
+
+var _ = Describe("DSI tolerations to K8s nodes taints", func() {
+	Context("DSI has tolerations to node taints", func() {
+		var (
+			err error
+
+			instance       Object
+			instanceNSN    string
+			instanceClient dsi.DSIClient
+
+			sb            *sbv1alpha1.ServiceBinding
+			sbCredentials secret.SecretData
+
+			portForwardStopCh chan struct{}
+			localPort         int
+
+			taints      []corev1.Taint
+			tolerations []corev1.Toleration
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+		})
+
+		AfterEach(func() {
+			close(portForwardStopCh)
+
+			Expect(tainter.untaintAllNodes(ctx, taints)).To(Succeed(), "failed to untaint nodes")
+
+			Expect(k8sClient.Delete(ctx, sb)).To(Succeed(),
+				"failed to delete DSI "+instanceNSN+"'s ServiceBinding")
+
+			Expect(k8sClient.Delete(ctx, instance.GetClientObject())).To(Succeed(),
+				"failed to delete DSI "+instanceNSN)
+		})
+
+		Context("One taint - one toleration", func() {
+			BeforeEach(func() {
+				taints = []corev1.Taint{
+					{
+						Key:    "a8s-test-taint-1",
+						Value:  "dummy-val-1",
+						Effect: "NoSchedule",
+					},
+				}
+				tolerations = []corev1.Toleration{
+					{
+						Key:      "a8s-test-taint-1",
+						Operator: corev1.TolerationOpEqual,
+						Value:    "dummy-val-1",
+						Effect:   "NoSchedule",
+					},
+				}
+
+				Expect(tainter.taintAllNodes(ctx, taints)).To(Succeed(), "failed to taint nodes")
+			})
+
+			It("Implements a 1-replica DSI that tolerates the node taint", func() {
+				replicas := int32(1)
+
+				By("Accepting the creation of the DSI API object", func() {
+					// Create the DSI K8s API object
+					instance, err = newDSI(dataservice, testingNamespace,
+						framework.GenerateName(instanceNamePrefix, GinkgoParallelProcess(),
+							suffixLength), replicas)
+					Expect(err).To(BeNil(), "failed to generate DSI object")
+					instanceNSN = instance.GetNamespace() + "/" + instance.GetName()
+					instance.SetTolerations(tolerations...)
+					Expect(k8sClient.Create(ctx, instance.GetClientObject())).To(Succeed(),
+						"failed to create DSI "+instanceNSN)
+				})
+
+				By("Creating a healthy StatefulSet for the DSI", func() {
+					Eventually(func(g Gomega) {
+						sset, err := instance.StatefulSet(ctx, k8sClient)
+						g.Expect(err).To(BeNil(), "failed to get the DSI "+instanceNSN+
+							"'s StatefulSet")
+						g.Expect(sset.Status.ReadyReplicas).To(Equal(replicas),
+							"ready replicas of DSI "+instanceNSN+
+								"'s StatefulSet don't match DSI's desired replicas")
+					}, 5*time.Minute).Should(Succeed(),
+						"failed to verify that the DSI's StatefulSet gets up and running")
+				})
+
+				By("Accepting a ServiceBinding to the DSI", func() {
+					sb = servicebinding.New(
+						servicebinding.SetNamespacedName(instance.GetClientObject()),
+						servicebinding.SetInstanceRef(instance.GetClientObject()),
+					)
+					Expect(k8sClient.Create(ctx, sb)).To(Succeed(),
+						"failed to create ServiceBinding for DSI "+instanceNSN)
+				})
+
+				By("Marking the ServiceBinding as implemented", func() {
+					Eventually(func(g Gomega) {
+						sbNSN := types.NamespacedName{Namespace: sb.Namespace, Name: sb.Name}
+						g.Expect(k8sClient.Get(ctx, sbNSN, sb)).
+							To(Succeed(), "failed to get DSI "+instanceNSN+"'s ServiceBinding")
+						g.Expect(sb.Status.Implemented).
+							To(BeTrue(), "ServiceBinding of DSI "+instanceNSN+" isn't implemented")
+					}, 10*time.Second).Should(Succeed(),
+						"failed to verify that the ServiceBinding of DSI "+instanceNSN+
+							" gets implemented")
+				})
+
+				By("Generating a client to the DSI to read/write to/from it", func() {
+					// Get credentials to write to the DSI
+					sbCredentials, err = secret.Data(
+						ctx, k8sClient, servicebinding.SecretName(sb.Name), testingNamespace)
+					Expect(err).To(BeNil(), "failed to parse secret data for ServiceBinding "+
+						sb.GetNamespace()+"/"+sb.GetName())
+
+					// Create a portforwarding to write to the DSI from out of cluster
+					portForwardStopCh, localPort, err = framework.PortForward(
+						ctx, instancePort, kubeconfigPath, instance, k8sClient)
+					Expect(err).To(BeNil(), "failed to establish portforward to DSI "+instanceNSN)
+
+					// Generate a client to the DSI using the credentials and the portforwarding
+					instanceClient, err = dsi.NewClient(dataservice,
+						strconv.Itoa(localPort),
+						sbCredentials)
+					Expect(err).To(BeNil(), "failed to create client to DSI "+instanceNSN)
+				})
+
+				By("Setting up the DSI so that clients can write/read data into/from it", func() {
+					Expect(instanceClient.Write(ctx, appsDefaultDB, "sample data")).To(Succeed(),
+						"failed to write into database "+appsDefaultDB+" in DSI "+instanceNSN)
+					readData, err := instanceClient.Read(ctx, appsDefaultDB)
+					Expect(err).To(BeNil(),
+						"failed to read data from database "+appsDefaultDB+" in DSI "+instanceNSN)
+					Expect(readData).To(Equal("sample data"),
+						"data read from database "+appsDefaultDB+" in DSI "+instanceNSN+
+							" doesn't match previously written data")
+				})
+			})
+
+			It("Implements a 3-replica DSI that tolerates the node taint", func() {
+				replicas := int32(3)
+
+				By("Accepting the creation of the DSI API object", func() {
+					// Create the DSI K8s API object
+					instance, err = newDSI(dataservice, testingNamespace,
+						framework.GenerateName(instanceNamePrefix, GinkgoParallelProcess(),
+							suffixLength), replicas)
+					Expect(err).To(BeNil(), "failed to generate DSI object")
+					instanceNSN = instance.GetNamespace() + "/" + instance.GetName()
+					instance.SetTolerations(tolerations...)
+					Expect(k8sClient.Create(ctx, instance.GetClientObject())).To(Succeed(),
+						"failed to create DSI "+instanceNSN)
+				})
+
+				By("Creating a healthy StatefulSet for the DSI", func() {
+					Eventually(func(g Gomega) {
+						sset, err := instance.StatefulSet(ctx, k8sClient)
+						g.Expect(err).To(BeNil(), "failed to get the DSI "+instanceNSN+
+							"'s StatefulSet")
+						g.Expect(sset.Status.ReadyReplicas).To(Equal(replicas),
+							"ready replicas of DSI "+instanceNSN+
+								"'s StatefulSet don't match DSI's desired replicas")
+					}, 5*time.Minute).Should(Succeed(),
+						"failed to verify that the DSI's StatefulSet gets up and running")
+				})
+
+				By("Accepting a ServiceBinding to the DSI", func() {
+					sb = servicebinding.New(
+						servicebinding.SetNamespacedName(instance.GetClientObject()),
+						servicebinding.SetInstanceRef(instance.GetClientObject()),
+					)
+					Expect(k8sClient.Create(ctx, sb)).To(Succeed(),
+						"failed to create ServiceBinding for DSI "+instanceNSN)
+				})
+
+				By("Marking the ServiceBinding as implemented", func() {
+					Eventually(func(g Gomega) {
+						sbNSN := types.NamespacedName{Namespace: sb.Namespace, Name: sb.Name}
+						g.Expect(k8sClient.Get(ctx, sbNSN, sb)).
+							To(Succeed(), "failed to get DSI "+instanceNSN+"'s ServiceBinding")
+						g.Expect(sb.Status.Implemented).
+							To(BeTrue(), "ServiceBinding of DSI "+instanceNSN+" isn't implemented")
+					}, 10*time.Second).Should(Succeed(),
+						"failed to verify that the ServiceBinding of DSI "+instanceNSN+
+							" gets implemented")
+				})
+
+				By("Generating a client to the DSI to read/write to/from it", func() {
+					// Get credentials to write to the DSI
+					sbCredentials, err = secret.Data(
+						ctx, k8sClient, servicebinding.SecretName(sb.Name), testingNamespace)
+					Expect(err).To(BeNil(), "failed to parse secret data for ServiceBinding "+
+						sb.GetNamespace()+"/"+sb.GetName())
+
+					// Create a portforwarding to write to the DSI from out of cluster
+					portForwardStopCh, localPort, err = framework.PortForward(
+						ctx, instancePort, kubeconfigPath, instance, k8sClient)
+					Expect(err).To(BeNil(), "failed to establish portforward to DSI "+instanceNSN)
+
+					// Generate a client to the DSI using the credentials and the portforwarding
+					instanceClient, err = dsi.NewClient(dataservice,
+						strconv.Itoa(localPort),
+						sbCredentials)
+					Expect(err).To(BeNil(), "failed to create client to DSI "+instanceNSN)
+				})
+
+				By("Setting up the DSI so that clients can write/read data into/from it", func() {
+					Expect(instanceClient.Write(ctx, appsDefaultDB, "sample data")).To(Succeed(),
+						"failed to write into database "+appsDefaultDB+" in DSI "+instanceNSN)
+					readData, err := instanceClient.Read(ctx, appsDefaultDB)
+					Expect(err).To(BeNil(),
+						"failed to read data from database "+appsDefaultDB+" in DSI "+instanceNSN)
+					Expect(readData).To(Equal("sample data"),
+						"data read from database "+appsDefaultDB+" in DSI "+instanceNSN+
+							" doesn't match previously written data")
+				})
+			})
+		})
+
+		Context("Two taints - two tolerations", func() {
+			BeforeEach(func() {
+				taints = []corev1.Taint{
+					{
+						Key:    "a8s-test-taint-1",
+						Value:  "dummy-val-1",
+						Effect: "NoSchedule",
+					},
+					{
+						Key:    "a8s-test-taint-2",
+						Value:  "dummy-val-2",
+						Effect: "NoSchedule",
+					},
+				}
+				tolerations = []corev1.Toleration{
+					{
+						Key:      "a8s-test-taint-1",
+						Operator: corev1.TolerationOpEqual,
+						Value:    "dummy-val-1",
+						Effect:   "NoSchedule",
+					},
+					{
+						Key:      "a8s-test-taint-2",
+						Operator: corev1.TolerationOpExists,
+						Effect:   "NoSchedule",
+					},
+				}
+
+				Expect(tainter.taintAllNodes(ctx, taints)).To(Succeed(), "failed to taint nodes")
+			})
+
+			It("Implements a 1-replica DSI that tolerates the node taints", func() {
+				replicas := int32(1)
+
+				By("Accepting the creation of the DSI API object", func() {
+					// Create the DSI K8s API object
+					instance, err = newDSI(dataservice, testingNamespace,
+						framework.GenerateName(instanceNamePrefix, GinkgoParallelProcess(),
+							suffixLength), replicas)
+					Expect(err).To(BeNil(), "failed to generate DSI object")
+					instanceNSN = instance.GetNamespace() + "/" + instance.GetName()
+					instance.SetTolerations(tolerations...)
+					Expect(k8sClient.Create(ctx, instance.GetClientObject())).To(Succeed(),
+						"failed to create DSI "+instanceNSN)
+				})
+
+				By("Creating a healthy StatefulSet for the DSI", func() {
+					Eventually(func(g Gomega) {
+						sset, err := instance.StatefulSet(ctx, k8sClient)
+						g.Expect(err).To(BeNil(), "failed to get the DSI "+instanceNSN+
+							"'s StatefulSet")
+						g.Expect(sset.Status.ReadyReplicas).To(Equal(replicas),
+							"ready replicas of DSI "+instanceNSN+
+								"'s StatefulSet don't match DSI's desired replicas")
+					}, 5*time.Minute).Should(Succeed(),
+						"failed to verify that the DSI's StatefulSet gets up and running")
+				})
+
+				By("Accepting a ServiceBinding to the DSI", func() {
+					sb = servicebinding.New(
+						servicebinding.SetNamespacedName(instance.GetClientObject()),
+						servicebinding.SetInstanceRef(instance.GetClientObject()),
+					)
+					Expect(k8sClient.Create(ctx, sb)).To(Succeed(),
+						"failed to create ServiceBinding for DSI "+instanceNSN)
+				})
+
+				By("Marking the ServiceBinding as implemented", func() {
+					Eventually(func(g Gomega) {
+						sbNSN := types.NamespacedName{Namespace: sb.Namespace, Name: sb.Name}
+						g.Expect(k8sClient.Get(ctx, sbNSN, sb)).
+							To(Succeed(), "failed to get DSI "+instanceNSN+"'s ServiceBinding")
+						g.Expect(sb.Status.Implemented).
+							To(BeTrue(), "ServiceBinding of DSI "+instanceNSN+" isn't implemented")
+					}, 10*time.Second).Should(Succeed(),
+						"failed to verify that the ServiceBinding of DSI "+instanceNSN+
+							" gets implemented")
+				})
+
+				By("Generating a client to the DSI to read/write to/from it", func() {
+					// Get credentials to write to the DSI
+					sbCredentials, err = secret.Data(
+						ctx, k8sClient, servicebinding.SecretName(sb.Name), testingNamespace)
+					Expect(err).To(BeNil(), "failed to parse secret data for ServiceBinding "+
+						sb.GetNamespace()+"/"+sb.GetName())
+
+					// Create a portforwarding to write to the DSI from out of cluster
+					portForwardStopCh, localPort, err = framework.PortForward(
+						ctx, instancePort, kubeconfigPath, instance, k8sClient)
+					Expect(err).To(BeNil(), "failed to establish portforward to DSI "+instanceNSN)
+
+					// Generate a client to the DSI using the credentials and the portforwarding
+					instanceClient, err = dsi.NewClient(dataservice,
+						strconv.Itoa(localPort),
+						sbCredentials)
+					Expect(err).To(BeNil(), "failed to create client to DSI "+instanceNSN)
+				})
+
+				By("Setting up the DSI so that clients can write/read data into/from it", func() {
+					Expect(instanceClient.Write(ctx, appsDefaultDB, "sample data")).To(Succeed(),
+						"failed to write into database "+appsDefaultDB+" in DSI "+instanceNSN)
+					readData, err := instanceClient.Read(ctx, appsDefaultDB)
+					Expect(err).To(BeNil(),
+						"failed to read data from database "+appsDefaultDB+" in DSI "+instanceNSN)
+					Expect(readData).To(Equal("sample data"),
+						"data read from database "+appsDefaultDB+" in DSI "+instanceNSN+
+							" doesn't match previously written data")
+				})
+			})
+
+			It("Implements a 3-replica DSI that tolerates the node taints", func() {
+				replicas := int32(3)
+
+				By("Accepting the creation of the DSI API object", func() {
+					// Create the DSI K8s API object
+					instance, err = newDSI(dataservice, testingNamespace,
+						framework.GenerateName(instanceNamePrefix, GinkgoParallelProcess(),
+							suffixLength), replicas)
+					Expect(err).To(BeNil(), "failed to generate DSI object")
+					instanceNSN = instance.GetNamespace() + "/" + instance.GetName()
+					instance.SetTolerations(tolerations...)
+					Expect(k8sClient.Create(ctx, instance.GetClientObject())).To(Succeed(),
+						"failed to create DSI "+instanceNSN)
+				})
+
+				By("Creating a healthy StatefulSet for the DSI", func() {
+					Eventually(func(g Gomega) {
+						sset, err := instance.StatefulSet(ctx, k8sClient)
+						g.Expect(err).To(BeNil(), "failed to get the DSI "+instanceNSN+
+							"'s StatefulSet")
+						g.Expect(sset.Status.ReadyReplicas).To(Equal(replicas),
+							"ready replicas of DSI "+instanceNSN+
+								"'s StatefulSet don't match DSI's desired replicas")
+					}, 5*time.Minute).Should(Succeed(),
+						"failed to verify that the DSI's StatefulSet gets up and running")
+				})
+
+				By("Accepting a ServiceBinding to the DSI", func() {
+					sb = servicebinding.New(
+						servicebinding.SetNamespacedName(instance.GetClientObject()),
+						servicebinding.SetInstanceRef(instance.GetClientObject()),
+					)
+					Expect(k8sClient.Create(ctx, sb)).To(Succeed(),
+						"failed to create ServiceBinding for DSI "+instanceNSN)
+				})
+
+				By("Marking the ServiceBinding as implemented", func() {
+					Eventually(func(g Gomega) {
+						sbNSN := types.NamespacedName{Namespace: sb.Namespace, Name: sb.Name}
+						g.Expect(k8sClient.Get(ctx, sbNSN, sb)).
+							To(Succeed(), "failed to get DSI "+instanceNSN+"'s ServiceBinding")
+						g.Expect(sb.Status.Implemented).
+							To(BeTrue(), "ServiceBinding of DSI "+instanceNSN+" isn't implemented")
+					}, 10*time.Second).Should(Succeed(),
+						"failed to verify that the ServiceBinding of DSI "+instanceNSN+
+							" gets implemented")
+				})
+
+				By("Generating a client to the DSI to read/write to/from it", func() {
+					// Get credentials to write to the DSI
+					sbCredentials, err = secret.Data(
+						ctx, k8sClient, servicebinding.SecretName(sb.Name), testingNamespace)
+					Expect(err).To(BeNil(), "failed to parse secret data for ServiceBinding "+
+						sb.GetNamespace()+"/"+sb.GetName())
+
+					// Create a portforwarding to write to the DSI from out of cluster
+					portForwardStopCh, localPort, err = framework.PortForward(
+						ctx, instancePort, kubeconfigPath, instance, k8sClient)
+					Expect(err).To(BeNil(), "failed to establish portforward to DSI "+instanceNSN)
+
+					// Generate a client to the DSI using the credentials and the portforwarding
+					instanceClient, err = dsi.NewClient(dataservice,
+						strconv.Itoa(localPort),
+						sbCredentials)
+					Expect(err).To(BeNil(), "failed to create client to DSI "+instanceNSN)
+				})
+
+				By("Setting up the DSI so that clients can write/read data into/from it", func() {
+					Expect(instanceClient.Write(ctx, appsDefaultDB, "sample data")).To(Succeed(),
+						"failed to write into database "+appsDefaultDB+" in DSI "+instanceNSN)
+					readData, err := instanceClient.Read(ctx, appsDefaultDB)
+					Expect(err).To(BeNil(),
+						"failed to read data from database "+appsDefaultDB+" in DSI "+instanceNSN)
+					Expect(readData).To(Equal("sample data"),
+						"data read from database "+appsDefaultDB+" in DSI "+instanceNSN+
+							" doesn't match previously written data")
+				})
+			})
+		})
+	})
+})


### PR DESCRIPTION

# Short Description
Add tests for the creation of DSIs that have tolerations to node taints.

# Details

1. This PR only tests the creation of DSIs that already have tolerations. It doesn't test updates to DSI tolerations and/or node taints, and doesn't test cases where the DSI is broken because it doesn't have the right tolerations. Those are left for follow-up epics. They were initially intended to be here but were left out for time reasons (i'm already really overtime with this epic) and because they are tricky to write (for example because the behavior can depend on the infrastructure provider via the used storage class). I'll create follow-up epics.
2. The tests added here have a lot of repetition - I couldn't find a clean way to avoid that. I think the best way is to migrate to Ginkgo V2 that supports table-driven tests. I'll create an epic.
3. While working on this I thought about some ideas to make our testing framework more ergonomic to use and reduce test speed at the same time. I'll create an epic about this too.

# Checks
- [x] Changelog has been updated
(https://anynines.atlassian.net/wiki/spaces/DS/pages/2423193626/Version+Control+Workflow)

Question: should commits that only touch tests end up in the changelog? They do not modify what the user is running. OTOH it might increase trust if we write that we improved our tests.
