### PR TITLE
Bump PG Operator image to v0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the a9s Dataservices on Kubernetes will be documented
 here, the format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/). 
 
+## [Unreleased]
+
+### Added
+
+- max_locks_per_transaction PostgreSQL configuration property has been added
+
+### Fixed
+
+- **breaking change** Fix bug that caused the event for the successful deletion of
+  a DSI to be emitted multiple times and before the deletion had actually
+  completed successfully
+- **breaking change** Fix issue where only a single event was emitted for two secrets
+  of a PostgreSQL instance
+
 ## [0.1.0] - 2022-06-27
 
 ### Added

--- a/deploy/a8s/manifests/postgresql-operator.yaml
+++ b/deploy/a8s/manifests/postgresql-operator.yaml
@@ -128,6 +128,25 @@ spec:
                       will trigger a restart of the PostgreSQL instance.
                     maximum: 262143
                     type: integer
+                  maxLocksPerTransaction:
+                    default: 64
+                    description: MaxLocksPerTransaction sets the maximum number of
+                      locks per transaction. The shared lock table tracks locks on
+                      max_locks_per_transaction * (max_connections + max_prepared_transactions)
+                      objects (e.g., tables); hence, no more than this many distinct
+                      objects can be locked at any one time. This parameter controls
+                      the average number of object locks allocated for each transaction;
+                      individual transactions can lock more objects as long as the
+                      locks of all transactions fit in the lock table. This is not
+                      the number of rows that can be locked; that value is unlimited.
+                      The default, 64, has historically proven sufficient, but you
+                      might need to raise this value if you have queries that touch
+                      many different tables in a single transaction, e.g., query of
+                      a parent table with many children. Updating MaxLocksPerTransaction
+                      will trigger a restart of the PostgreSQL instance.
+                    maximum: 2147483647
+                    minimum: 10
+                    type: integer
                   maxReplicationSlots:
                     default: 10
                     description: MaxReplicationSlots specifies the maximum number
@@ -1580,7 +1599,7 @@ spec:
         - --leader-elect
         command:
         - postgresql-operator
-        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/postgresql-operator:v0.31.0
+        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/postgresql-operator:v0.34.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/docs/application-developers/api_documentation.md
+++ b/docs/application-developers/api_documentation.md
@@ -2,15 +2,14 @@
 ## Packages
 
 - [postgresql.anynines.com/v1alpha1](#postgresqlanyninescomv1alpha1)
-- [backups.anynines.com/v1alpha1](#backupsanyninescomv1alpha1)
 - [servicebindings.anynines.com/v1alpha1](#servicebindingsanyninescomv1alpha1)
+- [backups.anynines.com/v1alpha1](#backupsanyninescomv1alpha1)
 
 ## postgresql.anynines.com/v1alpha1
 
 Package v1alpha1 contains API Schema definitions for the postgresql v1alpha1 API group
 
 ### Resource Types
-
 - [Postgresql](#postgresql)
 - [PostgresqlList](#postgresqllist)
 
@@ -25,6 +24,7 @@ _Appears in:_
 | `sharedBuffers` _integer_ | SharedBuffers sets the amount of memory (usually in 8KB) the database server uses for shared memory buffers. If this value is specified without units, it is taken as blocks, that is BLCKSZ bytes, typically 8kB. This setting must be at least 128 kilobytes. However, settings significantly higher than the minimum are usually needed for good performance. Updating SharedBuffers will trigger a restart of the PostgreSQL instance. |
 | `maxReplicationSlots` _integer_ | MaxReplicationSlots specifies the maximum number of replication slots that the server can support. Updating MaxReplicationSlots will trigger a restart of the PostgreSQL instance. |
 | `maxWALSenders` _integer_ | MaxWALSenders specifies the maximum number of concurrent connections from standby servers or streaming base backup clients (i.e., the maximum number of simultaneously running WAL sender processes). The value 0 means replication is disabled. Abrupt disconnection of a streaming client might leave an orphaned connection slot behind until a timeout is reached, so this parameter should be set slightly higher than the maximum number of expected clients so disconnected clients can immediately reconnect. Updating MaxWALSenders will trigger a restart of the PostgreSQL instance. |
+| `maxLocksPerTransaction` _integer_ | MaxLocksPerTransaction sets the maximum number of locks per transaction. The shared lock table tracks locks on max_locks_per_transaction * (max_connections + max_prepared_transactions) objects (e.g., tables); hence, no more than this many distinct objects can be locked at any one time. This parameter controls the average number of object locks allocated for each transaction; individual transactions can lock more objects as long as the locks of all transactions fit in the lock table. This is not the number of rows that can be locked; that value is unlimited. The default, 64, has historically proven sufficient, but you might need to raise this value if you have queries that touch many different tables in a single transaction, e.g., query of a parent table with many children. Updating MaxLocksPerTransaction will trigger a restart of the PostgreSQL instance. |
 | `statementTimeoutMillis` _integer_ | StatementTimeoutMillis is the timeout in milliseconds after which any statement that takes more than the specified number is aborted. The counter is started from the time the command arrives at the server from the client. If LogMinErrorStatement statement is set to ERROR or lower, the statement that timed out will also be logged. A value of zero (the default) turns this off. |
 | `sslCiphers` _string_ | SSLCiphers specifies the allowed SSL ciphers (https://www.postgresql.org/docs/13/runtime-config-connection.html#GUC-SSL-CIPHERS) |
 | `sslMinProtocolVersion` _string_ | SSLMinProtocolVersion sets the minimum SSL/TLS protocol version to use |
@@ -188,7 +188,6 @@ _Appears in:_
 | `implemented` _boolean_ | Implemented is `true` if and only if the service binding has been implemented by creating a user with the appropriate permissions in the bound Data Service Instance. Users can safely consume the service binding secret identified by `Secret` IF AND ONLY IF `Implemented` is true. In other words, even if the secret identified by `Secret` gets created before `Implemented` becomes true, users MUST NOT consume that secret before `Implemented` has become true. |
 | `error` _string_ | Error is a message explaining why the service binding could not be implemented if that's the case. |
 
-
 ## backups.anynines.com/v1alpha1
 
 Package v1alpha1 contains API Schema definitions for the backups v1alpha1 API group
@@ -328,7 +327,6 @@ _Appears in:_
 | `name` _string_ | Name is the name of the Kubernetes API resource that represents the Data Service Instance to backup or restore. |
 | `kind` _string_ | Kind is the kind of the Kubernetes API resource that represents the Data Service Instance to backup or restore (e.g. Postgresql, Redis, etc...). |
 | `apiGroup` _string_ | APIGroup is the API group of the Kubernetes API resource that represents the Data Service Instance to backup or restore (e.g. postgresql.anynines.com, redis.anynines.com, etc...). |
-
 
 #### StatusCondition
 

--- a/test/go.mod
+++ b/test/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/anynines/a8s-backup-manager v0.17.0
 	github.com/anynines/a8s-service-binding-controller v0.19.0
-	github.com/anynines/postgresql-operator v0.31.0
+	github.com/anynines/postgresql-operator v0.34.0
 	github.com/jackc/pgx/v4 v4.14.1
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -83,8 +83,8 @@ github.com/anynines/a8s-service-binding-controller v0.19.0/go.mod h1:441Y3rkCxnE
 github.com/anynines/a8s-shared/errors v0.0.0-20220513071445-4028a21718a7/go.mod h1:LqJbRqb+6EizOe4hM4qNEshCyzmWxtIyaDzXEwZ+QUs=
 github.com/anynines/postgresql-operator v0.28.0/go.mod h1:PHe6YhaMd626VC8BlcBz4vf32ERnUOQueMXRxStm86c=
 github.com/anynines/postgresql-operator v0.29.0/go.mod h1:PHe6YhaMd626VC8BlcBz4vf32ERnUOQueMXRxStm86c=
-github.com/anynines/postgresql-operator v0.31.0 h1:bnIdaVMfe5sqsp3VmA2f5LjWI/ycvYjVyINCdrRI3Iw=
-github.com/anynines/postgresql-operator v0.31.0/go.mod h1:iEN2CxXXEBlrxJ/5spcOqo2R/Qv9rfUD9eaPm24BJII=
+github.com/anynines/postgresql-operator v0.34.0 h1:SSHSeu5sr/fZK4a7Ua4JRMHWDckPrdOnoDs0bp7yK8A=
+github.com/anynines/postgresql-operator v0.34.0/go.mod h1:iEN2CxXXEBlrxJ/5spcOqo2R/Qv9rfUD9eaPm24BJII=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/test/integration/patroni/patroni_test.go
+++ b/test/integration/patroni/patroni_test.go
@@ -43,9 +43,10 @@ const (
 	MaxConnections        = "max_connections"
 	// SharedBuffers is not being set or updated.
 	// https://github.com/anynines/postgresql-operator/issues/75
-	SharedBuffers       = "shared_buffers"
-	MaxReplicationSlots = "max_replication_slots"
-	MaxWALSenders       = "max_wal_senders"
+	SharedBuffers          = "shared_buffers"
+	MaxReplicationSlots    = "max_replication_slots"
+	MaxWALSenders          = "max_wal_senders"
+	MaxLocksPerTransaction = "max_locks_per_transaction"
 )
 
 var (
@@ -93,6 +94,7 @@ var _ = Describe("Patroni Integration Tests", func() {
 				defaultTempFileLimitKiloBytes = -1
 				defaultTrackIOTiming          = "off"
 				defaultWalWriterDelayMillis   = 200 // Needs ms
+				defaultMaxLocksPerTransaction = 64
 			)
 
 			By("creating a PostgreSQL instance with implicit defaults", func() {
@@ -156,6 +158,7 @@ var _ = Describe("Patroni Integration Tests", func() {
 					// {SharedBuffers, defaultSharedBuffers},
 					{MaxReplicationSlots, strconv.Itoa(defaultMaxReplicationSlots)},
 					{MaxWALSenders, strconv.Itoa(defaultMaxWALSenders)},
+					{MaxLocksPerTransaction, strconv.Itoa(defaultMaxLocksPerTransaction)},
 				}
 
 				for _, setting := range expectedConfig {
@@ -242,6 +245,7 @@ var _ = Describe("Patroni Integration Tests", func() {
 					// {SharedBuffers, "200MB"}, // 2024 is converted to 200MB
 					{MaxReplicationSlots, strconv.Itoa(pg.Spec.PostgresConfiguration.MaxReplicationSlots)},
 					{MaxWALSenders, strconv.Itoa(pg.Spec.PostgresConfiguration.MaxWALSenders)},
+					{MaxLocksPerTransaction, strconv.Itoa(pg.Spec.PostgresConfiguration.MaxLocksPerTransaction)},
 				}
 
 				for _, setting := range expectedConfig {
@@ -318,9 +322,9 @@ var _ = Describe("Patroni Integration Tests", func() {
 						instance.GetNamespace(), instance.GetName()))
 			})
 
-			// Parameters such as max_connections, shared_buffers, max_replication_slots
-			// and max_wal_senders will require Patroni to restart the PostgreSQL
-			// process. We need to ensure that PostgreSQL has been successfully
+			// Parameters such as max_connections, shared_buffers, max_replication_slots,
+			// max_locks_per_transaction and max_wal_senders will require Patroni to restart the
+			// PostgreSQL process. We need to ensure that PostgreSQL has been successfully
 			// restarted by Patroni before we continue with our assertions. If we are
 			// unlucky PostgreSQL can be down at the time we make our first parameter
 			// assertion. In this case the portforward will break and not recover.
@@ -379,6 +383,7 @@ var _ = Describe("Patroni Integration Tests", func() {
 					// {SharedBuffers, "200MB"}, // 2024 is converted to 200MB
 					{MaxReplicationSlots, strconv.Itoa(pg.Spec.PostgresConfiguration.MaxReplicationSlots)},
 					{MaxWALSenders, strconv.Itoa(pg.Spec.PostgresConfiguration.MaxWALSenders)},
+					{MaxLocksPerTransaction, strconv.Itoa(pg.Spec.PostgresConfiguration.MaxLocksPerTransaction)},
 				}
 
 				for _, setting := range expectedConfig {
@@ -428,6 +433,7 @@ var _ = Describe("Patroni Integration Tests", func() {
 
 func setCustomPostgresConfig(pg *v1alpha1.Postgresql) {
 	pg.Spec.PostgresConfiguration.MaxConnections = 101
+	pg.Spec.PostgresConfiguration.MaxLocksPerTransaction = 120
 	// SharedBuffers is not being set or updated.
 	// https://github.com/anynines/postgresql-operator/issues/75
 	pg.Spec.PostgresConfiguration.SharedBuffers = 200


### PR DESCRIPTION
# Short Description

* Bump PG Operator image from v0.31.0 to v0.34.0
* Bump PG Operator version for integration tests to v0.34.0
* Adjust integration tests as a bug in the PG Operator has been fixed
* Extend integration tests to cover the max_locks_per_transaction
  parameter

# Details

Integration of a8s_698 into a8s-deployment. Also adjust the PG integration
tests as a known bug has been fixed.

# Checks
- [x] Documentation has been adjusted
- [x] Architectural decisions have been documented
- [x] Changelog has been updated
- [x] Manifests are updated
- [x] Commit message adheres to our [guideline](https://anynines.atlassian.net/wiki/spaces/DS/pages/2423193626/Version+Control+Workflow)
