### PR TITLE
A8s 743 add labeling of nodes

### DIFF
--- a/test/integration/framework/dsi/dsi.go
+++ b/test/integration/framework/dsi/dsi.go
@@ -36,6 +36,11 @@ type TolerationsSetter interface {
 	SetTolerations(...corev1.Toleration)
 }
 
+type WithPodAntiAffinity interface {
+	AddRequiredPodAntiAffinityTerm(antiAffinityTerm corev1.PodAffinityTerm)
+	AddPreferredPodAntiAffinityTerm(weight int, antiAffinityTerm corev1.PodAffinityTerm)
+}
+
 type StatefulSetGetter interface {
 	StatefulSet(context.Context, runtimeClient.Client) (*appsv1.StatefulSet, error)
 }

--- a/test/integration/framework/node/client.go
+++ b/test/integration/framework/node/client.go
@@ -7,7 +7,9 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/errors"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 var (
@@ -26,16 +28,88 @@ type Client struct {
 	MasterNodeTaints map[string]struct{}
 }
 
-func (c Client) TaintAll(ctx context.Context, t []v1.Taint) error {
-	nodes, err := c.Nodes.List(ctx, metav1.ListOptions{})
+func NewClientFromKubecfg(kubecfg string) (Client, error) {
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubecfg)
 	if err != nil {
-		return fmt.Errorf("failed to list all K8s nodes to taint: %w", err)
+		return Client{}, fmt.Errorf("failed to create client config for K8s nodes client from "+
+			"kubeconig %s: %w", kubecfg, err)
 	}
 
-	for _, n := range nodes.Items {
+	cv1Client, err := corev1client.NewForConfig(cfg)
+	if err != nil {
+		return Client{},
+			fmt.Errorf("failed to create client for K8s cluster nodes from config %v: %w", cfg, err)
+	}
+
+	return Client{
+		Nodes:            cv1Client.Nodes(),
+		MasterNodeTaints: MasterTaintKeys,
+	}, nil
+}
+
+func (c Client) GetLabels(ctx context.Context, nodeName string) (map[string]string, error) {
+	node, err := c.Nodes.Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get labels for node %s: failed to get node: %w",
+			nodeName, err)
+	}
+
+	if node == nil {
+		return nil, nil
+	}
+
+	return node.Labels, nil
+}
+
+// ListAll returns a slice with all the nodes in the K8s cluster.
+// ListAll returns an empty slice and an error if a failure occurs.
+func (c Client) ListAll(ctx context.Context) ([]v1.Node, error) {
+	nodes, err := c.Nodes.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list K8s cluster nodes: %w", err)
+	}
+	return nodes.Items, nil
+}
+
+// ListWorkers returns a slice with all the worker nodes in the K8s cluster.
+// Worker nodes are nodes that DO NOT have the taints with the keys contained in
+// `c.MasterNodeTaints`.
+// ListWorkers returns an empty slice and an error if a failure occurs.
+func (c Client) ListWorkers(ctx context.Context) ([]v1.Node, error) {
+	allNodes, err := c.ListAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	workerNodes := make([]v1.Node, 0, len(allNodes))
+	for _, n := range allNodes {
+		if !c.hasMasterNodeTaints(n.Spec.Taints) {
+			workerNodes = append(workerNodes, n)
+		}
+	}
+
+	return workerNodes, nil
+}
+
+// TaintWorkers adds the taints `t` to all the worker nodes in the K8s cluster.
+// Worker nodes are nodes that DO NOT have the taints with the keys contained in
+// `c.MasterNodeTaints`.
+// TaintWorkers is idempotent:
+//   - if a worker already has a subset of the taints in `t`, only the missing ones are added.
+//   - if a worker already has all the taints in `t`, it's left unchanged.
+// If a worker has one (or more) taint(s) with the same key as one of the taints in `t` but
+// different value or effect, TaintWorkers panics.
+// TaintWorkers returns an error if a failure occurs.
+func (c Client) TaintWorkers(ctx context.Context, t []v1.Taint) error {
+	workers, err := c.ListWorkers(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to taint K8s worker nodes: %w", err)
+	}
+
+	for _, w := range workers {
 		// TODO: consider moving on to taint other nodes when an error occurs here (while keeping
 		// the error).
-		if err := c.taint(ctx, n, t); err != nil {
+		if err := c.taint(ctx, w, t); err != nil {
 			return err
 		}
 	}
@@ -43,13 +117,20 @@ func (c Client) TaintAll(ctx context.Context, t []v1.Taint) error {
 	return nil
 }
 
+// UntaintAll removes the taints `t` from all the nodes (worker and master ones) in the K8s cluster.
+// UntaintAll is idempotent:
+//   - if a node has only a subset of the taints in `t`, only that subset is removed.
+//   - if a node doesn't have any of the taints in `t`, it's left unchanged.
+// If a node has one (or more) taint(s) with the same key as one of the taints in `t` but different
+// value or effect, UntaintAll panics.
+// UntaintAll returns an error if a failure occurs.
 func (c Client) UntaintAll(ctx context.Context, t []v1.Taint) error {
-	nodes, err := c.Nodes.List(ctx, metav1.ListOptions{})
+	nodes, err := c.ListAll(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to list all K8s nodes to untaint: %w", err)
+		return fmt.Errorf("failed to untaint K8s nodes: %w", err)
 	}
 
-	for _, n := range nodes.Items {
+	for _, n := range nodes {
 		// TODO: consider moving on to untaint other nodes when an error occurs here (while keeping
 		// the error).
 		if err := c.untaint(ctx, n, t); err != nil {
@@ -60,20 +141,45 @@ func (c Client) UntaintAll(ctx context.Context, t []v1.Taint) error {
 	return nil
 }
 
-func (c Client) taint(ctx context.Context, n v1.Node, t []v1.Taint) error {
-	if c.hasMasterNodeTaints(n.Spec.Taints) {
-		// TODO: stop relying on std logging library, and fix logging all over the code that
-		// supports tests (either use what Ginkgo recommends or what we use in controllers).
-		log.Printf("Warning: Did not taint node %s as it has a well known master taint", n.Name)
-		return nil
+// UnlabelAll removes the labels with the keys in `labelsKeys` from all the nodes (worker and master
+// ones) in the K8s cluster, regardless of the labels values.
+// UnlabelAll is idempotent:
+//   - if a node has only a subset of the labels in `labelsKeys`, only that subset is removed.
+//   - if a node doesn't have any of the labels in `labelsKeys`, it's left unchanged.
+// UnlabelAll returns an error if a failure occurs.
+func (c Client) UnlabelAll(ctx context.Context, labelsKeys []string) error {
+	nodes, err := c.ListAll(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to unlabel K8s nodes: %w", err)
 	}
 
+	// Here we don't fail fast. Rather than returning an error on the first failure, we try to
+	// unlabel as many nodes as possible, i.e., even if unlabeling a node fails we try to unlabel
+	// the remaining nodes. This is done because users of this library are e2e and integration tests
+	// that require unlabeling to succeed, and will retry it if it fails, so it's actually faster
+	// to always try to unlabel as many nodes as possible. This is safe because unlabeling is
+	// idempotent.
+	var errs []error
+	for _, n := range nodes {
+		if err := c.unlabel(ctx, n, labelsKeys); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("unlabeling all or some nodes failed: %v", errors.NewAggregate(errs))
+	}
+
+	return nil
+}
+
+func (c Client) taint(ctx context.Context, n v1.Node, t []v1.Taint) error {
 	if len(n.Spec.Taints) > 0 {
 		log.Printf("Warning: Node %s already is tainted with taints %v. This might break the "+
 			"tolerations tests", n.Name, n.Spec.Taints)
 	}
 
-	newTaints := union(n.Spec.Taints, t)
+	newTaints := taintsUnion(n.Spec.Taints, t)
 	if len(newTaints) == len(n.Spec.Taints) {
 		return nil
 	}
@@ -87,7 +193,7 @@ func (c Client) taint(ctx context.Context, n v1.Node, t []v1.Taint) error {
 }
 
 func (c Client) untaint(ctx context.Context, n v1.Node, t []v1.Taint) error {
-	newTaints := diff(n.Spec.Taints, t)
+	newTaints := taintsDiff(n.Spec.Taints, t)
 	if len(newTaints) == len(n.Spec.Taints) {
 		return nil
 	}
@@ -100,7 +206,42 @@ func (c Client) untaint(ctx context.Context, n v1.Node, t []v1.Taint) error {
 	return nil
 }
 
-func union(x, y []v1.Taint) []v1.Taint {
+func (c Client) Label(ctx context.Context, n v1.Node, labels map[string]string) error {
+	newLabels := labelsUnion(n.Labels, labels)
+	if len(newLabels) == len(n.Labels) {
+		return nil
+	}
+
+	n.Labels = newLabels
+	if _, err := c.Nodes.Update(ctx, &n, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update of node %s to add labels %v failed: %w", n.Name, labels, err)
+	}
+
+	return nil
+}
+
+func (c Client) unlabel(ctx context.Context, n v1.Node, labelsKeysToRemove []string) error {
+	labelsChanged := false
+	for _, key := range labelsKeysToRemove {
+		if _, found := n.Labels[key]; found {
+			delete(n.Labels, key)
+			labelsChanged = true
+		}
+	}
+
+	if !labelsChanged {
+		return nil
+	}
+
+	if _, err := c.Nodes.Update(ctx, &n, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update of node %s to remove labels with keys %v failed: %w",
+			n.Name, labelsKeysToRemove, err)
+	}
+
+	return nil
+}
+
+func taintsUnion(x, y []v1.Taint) []v1.Taint {
 	taintKeyToTaint := make(map[string]v1.Taint, len(x)+len(y))
 
 	for _, t := range x {
@@ -126,7 +267,7 @@ func union(x, y []v1.Taint) []v1.Taint {
 	return union
 }
 
-func diff(x, y []v1.Taint) []v1.Taint {
+func taintsDiff(x, y []v1.Taint) []v1.Taint {
 	taintKeyToTaint := make(map[string]v1.Taint, len(x))
 
 	for _, t := range x {
@@ -150,6 +291,20 @@ func diff(x, y []v1.Taint) []v1.Taint {
 		diff = append(diff, t)
 	}
 	return diff
+}
+
+func labelsUnion(x, y map[string]string) map[string]string {
+	union := make(map[string]string, len(x)+len(y))
+
+	for key, val := range x {
+		union[key] = val
+	}
+
+	for key, val := range y {
+		union[key] = val
+	}
+
+	return union
 }
 
 func (c Client) hasMasterNodeTaints(taints []v1.Taint) bool {

--- a/test/integration/framework/node/client_test.go
+++ b/test/integration/framework/node/client_test.go
@@ -2,14 +2,18 @@ package node_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"sort"
+	"strings"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stest "k8s.io/client-go/testing"
 
 	"github.com/anynines/a8s-deployment/test/integration/framework/node"
 )
@@ -24,7 +28,772 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestTaintAllHappyPaths(t *testing.T) {
+func TestListAllHappyPaths(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		nodes []v1.Node
+	}{
+		"0_nodes_returned_when_there_are_0_nodes": {nodes: []v1.Node{}},
+
+		"1_node_is_returned_when_there_is_1_node": {nodes: []v1.Node{newNode(withName("n1"))}},
+
+		"3_nodes_are_returned_when_there_are_3_nodes": {nodes: []v1.Node{
+			newNode(withName("n1")),
+			newNode(withName("n2")),
+			newNode(withName("n3")),
+		}},
+
+		"nodes_with_master_taint_are_returned_together_with_worker_nodes": {nodes: []v1.Node{
+			newNode(withName("worker-node")),
+			newNode(
+				withName("master-node"),
+				withTaints([]v1.Taint{
+					{Key: "node-role.kubernetes.io/master", Effect: "NoSchedule"},
+				}),
+			),
+		}},
+
+		"nodes_with_control_plane_taint_are_returned_together_with_worker_nodes": {nodes: []v1.Node{
+			newNode(withName("worker-node")),
+			newNode(
+				withName("control-plane-node"),
+				withTaints([]v1.Taint{
+					{Key: "node-role.kubernetes.io/control-plane", Effect: "NoSchedule"},
+				}),
+			),
+		}},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// Rebind tc into this lexical scope. Details on the why at
+			// https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
+			tc := tc
+
+			t.Parallel()
+
+			// Set up fake K8s client pre-populated with the nodes that exist in the test case.
+			k8sAPINodesClient := fake.
+				NewSimpleClientset(&v1.NodeList{Items: tc.nodes}).
+				CoreV1().
+				Nodes()
+
+			// Set up object under test with the fake K8s client.
+			nodes := node.Client{
+				Nodes:            k8sAPINodesClient,
+				MasterNodeTaints: node.MasterTaintKeys,
+			}
+
+			// Invoke the method under test.
+			gotNodes, err := nodes.ListAll(context.Background())
+
+			if err != nil {
+				t.Fatalf("Expected no error when invoking ListAll, got error: \"%v\"", err)
+			}
+
+			// Compare the expected nodes with the got ones to assess the test outcome.
+			if !equality.Semantic.DeepEqual(tc.nodes, gotNodes) {
+				t.Fatalf("Expected nodes don't match got ones\n\n\texpected: %#+v\n\n\tgot:"+
+					" %#+v\n\n", tc.nodes, gotNodes)
+			}
+		})
+	}
+}
+
+func TestListAllFails(t *testing.T) {
+	t.Parallel()
+
+	// Define a fake K8s client that is pre-populated with a test node.
+	testNode := newNode(withName("n1"))
+	k8sClient := fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{testNode}})
+
+	// "Sabotage" the fake K8s client by adding to it a function that intercepts LIST API calls
+	// and makes them fail returning an error.
+	testErr := errors.New("dummy error")
+	listSabotager := func(k8stest.Action) (bool, runtime.Object, error) {
+		return true, nil, testErr
+	}
+	k8sClient.PrependReactor("list", "nodes", listSabotager)
+
+	// Set up the object under test with the sabotaged client that will make K8s LIST calls fail.
+	nodes := node.Client{
+		Nodes:            k8sClient.CoreV1().Nodes(),
+		MasterNodeTaints: node.MasterTaintKeys,
+	}
+
+	// Invoke the method under test
+	gotNodes, gotErr := nodes.ListAll(context.Background())
+
+	if gotErr == nil {
+		t.Fatal("got nil error, expected non-nil error")
+	}
+
+	if !strings.Contains(strings.ToLower(gotErr.Error()), "list") {
+		t.Fatalf("got error \"%v\" should contain the word \"list\" (in any case) but it doesn't",
+			gotErr)
+	}
+
+	if !strings.Contains(gotErr.Error(), testErr.Error()) {
+		t.Fatalf("got error \"%v\" should contain the error message \"%v\" returned by the "+
+			"K8s API but it doesn't", gotErr, testErr)
+	}
+
+	if len(gotNodes) != 0 {
+		t.Fatalf("no node should be returned on error, but got non-empty nodes list %#+v", gotNodes)
+	}
+}
+
+func TestListWorkersHappyPaths(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		inputNodes    []v1.Node
+		expectedNodes []v1.Node
+	}{
+		"0_workers_returned_when_there_are_0_nodes": {
+			inputNodes:    []v1.Node{},
+			expectedNodes: []v1.Node{},
+		},
+
+		"1_worker_is_returned_when_there_is_1_worker": {
+			inputNodes:    []v1.Node{newNode(withName("worker-1"))},
+			expectedNodes: []v1.Node{newNode(withName("worker-1"))},
+		},
+
+		"3_workers_are_returned_when_there_are_3_workers": {
+			inputNodes: []v1.Node{
+				newNode(withName("worker-1")),
+				newNode(withName("worker-2")),
+				newNode(withName("worker-3")),
+			},
+			expectedNodes: []v1.Node{
+				newNode(withName("worker-1")),
+				newNode(withName("worker-2")),
+				newNode(withName("worker-3")),
+			},
+		},
+
+		"only_workers_are_returned_when_there_are_nodes_with_master_taint": {
+			inputNodes: []v1.Node{
+				newNode(withName("worker-node")),
+				newNode(
+					withName("master-node"),
+					withTaints([]v1.Taint{
+						{Key: "node-role.kubernetes.io/master", Effect: "NoSchedule"},
+					}),
+				),
+			},
+			expectedNodes: []v1.Node{newNode(withName("worker-node"))},
+		},
+
+		"only_workers_are_returned_when_there_are_nodes_with_control_plane_taint": {
+			inputNodes: []v1.Node{
+				newNode(withName("worker-node")),
+				newNode(
+					withName("control-plane-node"),
+					withTaints([]v1.Taint{
+						{Key: "node-role.kubernetes.io/control-plane", Effect: "NoSchedule"},
+					}),
+				),
+			},
+			expectedNodes: []v1.Node{newNode(withName("worker-node"))},
+		},
+
+		"no_node_is_returned_when_all_nodes_have_the_master_taint": {
+			inputNodes: []v1.Node{
+				newNode(
+					withName("master-node"),
+					withTaints([]v1.Taint{
+						{Key: "node-role.kubernetes.io/master", Effect: "NoSchedule"},
+					}),
+				),
+			},
+			expectedNodes: []v1.Node{},
+		},
+
+		"no_node_is_returned_when_all_nodes_have_the_control_plane_taint": {
+			inputNodes: []v1.Node{
+				newNode(
+					withName("control-plane-node"),
+					withTaints([]v1.Taint{
+						{Key: "node-role.kubernetes.io/control-plane", Effect: "NoSchedule"},
+					}),
+				),
+			},
+			expectedNodes: []v1.Node{},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// Rebind tc into this lexical scope. Details on the why at
+			// https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
+			tc := tc
+
+			t.Parallel()
+
+			// Set up fake K8s client pre-populated with the nodes that exist in the test case.
+			k8sAPINodesClient := fake.
+				NewSimpleClientset(&v1.NodeList{Items: tc.inputNodes}).
+				CoreV1().
+				Nodes()
+
+			// Set up object under test with the fake K8s client.
+			nodes := node.Client{
+				Nodes:            k8sAPINodesClient,
+				MasterNodeTaints: node.MasterTaintKeys,
+			}
+
+			// Invoke the method under test.
+			gotNodes, err := nodes.ListWorkers(context.Background())
+
+			if err != nil {
+				t.Fatalf("Expected no error when invoking ListWorkers, got error: \"%v\"", err)
+			}
+
+			// Compare the expected nodes with the got ones to assess the test outcome.
+			if !equality.Semantic.DeepEqual(tc.expectedNodes, gotNodes) {
+				t.Fatalf("Expected nodes don't match got ones\n\n\texpected: %#+v\n\n\tgot:"+
+					" %#+v\n\n", tc.expectedNodes, gotNodes)
+			}
+		})
+	}
+}
+
+func TestListWorkersFails(t *testing.T) {
+	t.Parallel()
+
+	// Define a fake K8s client that is pre-populated with a test node.
+	testNode := newNode(withName("n1"))
+	k8sClient := fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{testNode}})
+
+	// "Sabotage" the fake K8s client by adding to it a function that intercepts LIST API calls
+	// and makes them fail returning an error.
+	testErr := errors.New("dummy error")
+	listSabotager := func(k8stest.Action) (bool, runtime.Object, error) {
+		return true, nil, testErr
+	}
+	k8sClient.PrependReactor("list", "nodes", listSabotager)
+
+	// Set up the object under test with the sabotaged client that will make K8s LIST calls fail.
+	nodes := node.Client{
+		Nodes:            k8sClient.CoreV1().Nodes(),
+		MasterNodeTaints: node.MasterTaintKeys,
+	}
+
+	// Invoke the method under test
+	gotNodes, gotErr := nodes.ListWorkers(context.Background())
+
+	if gotErr == nil {
+		t.Fatal("got nil error, expected non-nil error")
+	}
+
+	if !strings.Contains(strings.ToLower(gotErr.Error()), "list") {
+		t.Fatalf("got error \"%v\" should contain the word \"list\" (in any case) but it doesn't",
+			gotErr)
+	}
+
+	if !strings.Contains(gotErr.Error(), testErr.Error()) {
+		t.Fatalf("got error \"%v\" should contain the error message \"%v\" returned by the "+
+			"K8s API but it doesn't", gotErr, testErr)
+	}
+
+	if len(gotNodes) != 0 {
+		t.Fatalf("no node should be returned on error, but got non-empty nodes list %#+v", gotNodes)
+	}
+}
+
+func TestUnlabelAllHappyPaths(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		keysOfLabelsToRemove []string
+		inputNodes           []v1.Node
+		expectedNodes        []v1.Node
+	}{
+		"nodes_with_no_labels_are_left_unchanged": {
+			keysOfLabelsToRemove: []string{"a8s.key1"},
+			inputNodes: []v1.Node{
+				newNode(withName("n1"), withLabels(nil)),
+				newNode(withName("n2"), withLabels(map[string]string{})),
+			},
+			expectedNodes: []v1.Node{
+				newNode(withName("n1"), withLabels(nil)),
+				newNode(withName("n2"), withLabels(map[string]string{})),
+			},
+		},
+
+		"1_label_removed_from_1_node_with_no_other_labels": {
+			keysOfLabelsToRemove: []string{"a8s.key1"},
+			inputNodes: []v1.Node{
+				newNode(
+					withName("n1"),
+					withLabels(map[string]string{"a8s.key1": "val1"}),
+				),
+			},
+			expectedNodes: []v1.Node{newNode(withName("n1"), withLabels(nil))},
+		},
+
+		"2_labels_removed_from_1_node_with_no_other_labels": {
+			keysOfLabelsToRemove: []string{"a8s.key1", "a8s.key2"},
+			inputNodes: []v1.Node{
+				newNode(
+					withName("n1"),
+					withLabels(map[string]string{
+						"a8s.key1": "val1",
+						"a8s.key2": "val2",
+					}),
+				),
+			},
+			expectedNodes: []v1.Node{newNode(withName("n1"), withLabels(nil))},
+		},
+
+		"1_label_removed_from_1_node_that_has_other_labels_as_well": {
+			keysOfLabelsToRemove: []string{"a8s.key1"},
+			inputNodes: []v1.Node{
+				newNode(
+					withName("n1"),
+					withLabels(map[string]string{
+						"a8s.key1": "val1",
+						"key10":    "val10",
+					}),
+				),
+			},
+			expectedNodes: []v1.Node{
+				newNode(
+					withName("n1"),
+					withLabels(map[string]string{"key10": "val10"}),
+				),
+			},
+		},
+
+		"2_labels_removed_from_1_node_that_has_other_labels_as_well": {
+			keysOfLabelsToRemove: []string{"a8s.key1", "a8s.key2"},
+			inputNodes: []v1.Node{
+				newNode(
+					withName("n1"),
+					withLabels(map[string]string{
+						"a8s.key1": "val1",
+						"key10":    "val10",
+						"a8s.key2": "val2",
+					}),
+				),
+			},
+			expectedNodes: []v1.Node{
+				newNode(
+					withName("n1"),
+					withLabels(map[string]string{"key10": "val10"}),
+				),
+			},
+		},
+
+		"2_labels_removed_from_2_nodes_that_have_no_other_labels": {
+			keysOfLabelsToRemove: []string{"a8s.key1", "a8s.key2"},
+			inputNodes: []v1.Node{
+				newNode(
+					withName("n1"),
+					withLabels(map[string]string{
+						"a8s.key1": "val1",
+						"a8s.key2": "val2",
+					}),
+				),
+				newNode(
+					withName("n2"),
+					withLabels(map[string]string{
+						"a8s.key1": "val1",
+						"a8s.key2": "val2",
+					}),
+				),
+			},
+			expectedNodes: []v1.Node{
+				newNode(withName("n1"), withLabels(nil)),
+				newNode(withName("n2"), withLabels(nil)),
+			},
+		},
+
+		"2_labels_removed_from_2_nodes_1_with_other_labels_as_well": {
+			keysOfLabelsToRemove: []string{"a8s.key1", "a8s.key2"},
+			inputNodes: []v1.Node{
+				newNode(
+					withName("n1"),
+					withLabels(map[string]string{
+						"a8s.key1": "val1",
+						"a8s.key2": "val2",
+					}),
+				),
+				newNode(
+					withName("n2"),
+					withLabels(map[string]string{
+						"a8s.key1": "val1",
+						"a8s.key2": "val2",
+						"key10":    "val10",
+						"key20":    "val20",
+					}),
+				),
+			},
+			expectedNodes: []v1.Node{
+				newNode(withName("n1"), withLabels(nil)),
+				newNode(
+					withName("n2"),
+					withLabels(map[string]string{
+						"key10": "val10",
+						"key20": "val20",
+					}),
+				),
+			},
+		},
+
+		"1_node_with_labels_but_not_the_ones_to_remove_is_left_unchanged": {
+			keysOfLabelsToRemove: []string{"a8s.key1", "a8s.key2"},
+			inputNodes: []v1.Node{
+				newNode(
+					withName("n1"),
+					withLabels(map[string]string{
+						"key10": "val10",
+						"key20": "val20",
+					}),
+				),
+			},
+			expectedNodes: []v1.Node{
+				newNode(
+					withName("n1"),
+					withLabels(map[string]string{
+						"key10": "val10",
+						"key20": "val20",
+					}),
+				),
+			},
+		},
+
+		"2_labels_are_removed_from_nodes_that_have_them_but_other_nodes_are_unchanged": {
+			keysOfLabelsToRemove: []string{"a8s.key1", "a8s.key2"},
+			inputNodes: []v1.Node{
+				newNode(
+					withName("n1"),
+					withLabels(map[string]string{
+						"a8s.key1": "val1",
+						"a8s.key2": "val2",
+					}),
+				),
+				newNode(
+					withName("n2"),
+					withLabels(map[string]string{
+						"key10": "val10",
+						"key20": "val20",
+					}),
+				),
+			},
+			expectedNodes: []v1.Node{
+				newNode(withName("n1"), withLabels(nil)),
+				newNode(
+					withName("n2"),
+					withLabels(map[string]string{
+						"key10": "val10",
+						"key20": "val20",
+					}),
+				),
+			},
+		},
+
+		"only_the_labels_to_remove_that_a_node_has_are_removed": {
+			keysOfLabelsToRemove: []string{"a8s.key1", "a8s.key2"},
+			inputNodes: []v1.Node{
+				newNode(
+					withName("n1"),
+					withLabels(map[string]string{
+						"a8s.key1": "val1",
+						"key10":    "val10",
+					}),
+				),
+			},
+			expectedNodes: []v1.Node{
+				newNode(
+					withName("n1"),
+					withLabels(map[string]string{"key10": "val10"}),
+				),
+			},
+		},
+
+		"when_removing_2_labels_from_4_nodes_only_the_labels_that_the_nodes_have_are_removed": {
+			keysOfLabelsToRemove: []string{"a8s.key1", "a8s.key2"},
+			inputNodes: []v1.Node{
+				newNode(withName("n1"), withLabels(nil)),
+				newNode(
+					withName("n2"),
+					withLabels(map[string]string{
+						"a8s.key1": "val1",
+						"key10":    "val10",
+					}),
+				),
+				newNode(
+					withName("n3"),
+					withLabels(map[string]string{"key10": "val10"}),
+				),
+				newNode(
+					withName("n4"),
+					withLabels(map[string]string{
+						"a8s.key1": "val1",
+						"a8s.key2": "val2",
+					}),
+				),
+			},
+			expectedNodes: []v1.Node{
+				newNode(withName("n1"), withLabels(nil)),
+				newNode(
+					withName("n2"),
+					withLabels(map[string]string{"key10": "val10"}),
+				),
+				newNode(
+					withName("n3"),
+					withLabels(map[string]string{"key10": "val10"}),
+				),
+				newNode(withName("n4"), withLabels(nil)),
+			},
+		},
+
+		"2_labels_are_removed_from_a_node_with_master_taints": {
+			keysOfLabelsToRemove: []string{"a8s.key1", "a8s.key2"},
+			inputNodes: []v1.Node{
+				newNode(
+					withName("n1"),
+					withLabels(map[string]string{
+						"a8s.key1": "val1",
+						"a8s.key2": "val2",
+					}),
+					withTaints([]v1.Taint{
+						{Key: "node-role.kubernetes.io/master", Effect: "NoExecute"},
+					}),
+				),
+			},
+			expectedNodes: []v1.Node{
+				newNode(
+					withName("n1"),
+					withLabels(nil),
+					withTaints([]v1.Taint{
+						{Key: "node-role.kubernetes.io/master", Effect: "NoExecute"},
+					}),
+				),
+			},
+		},
+
+		"2_labels_are_removed_from_a_node_with_control_plane_taints": {
+			keysOfLabelsToRemove: []string{"a8s.key1", "a8s.key2"},
+			inputNodes: []v1.Node{
+				newNode(
+					withName("n1"),
+					withLabels(map[string]string{
+						"a8s.key1": "val1",
+						"a8s.key2": "val2",
+					}),
+					withTaints([]v1.Taint{
+						{Key: "node-role.kubernetes.io/control-plane", Effect: "NoExecute"},
+					}),
+				),
+			},
+			expectedNodes: []v1.Node{
+				newNode(
+					withName("n1"),
+					withLabels(nil),
+					withTaints([]v1.Taint{
+						{Key: "node-role.kubernetes.io/control-plane", Effect: "NoExecute"},
+					}),
+				),
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// Rebind tc into this lexical scope. Details on the why at
+			// https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
+			tc := tc
+
+			t.Parallel()
+
+			// Set up object under test
+			k8sAPINodesClient := fake.
+				NewSimpleClientset(&v1.NodeList{Items: tc.inputNodes}).
+				CoreV1().
+				Nodes()
+			nodes := node.Client{
+				Nodes:            k8sAPINodesClient,
+				MasterNodeTaints: node.MasterTaintKeys,
+			}
+
+			// Invoke method under test
+			if err := nodes.UnlabelAll(context.Background(), tc.keysOfLabelsToRemove); err != nil {
+				t.Fatal("Expected no error when invoking UnlabelAll, got:", err)
+			}
+
+			// Get the nodes after invoking the method under test
+			gotNodesList, err := k8sAPINodesClient.List(context.Background(), metav1.ListOptions{})
+			if err != nil {
+				t.Fatal("Expected no error when listing nodes, got:", err)
+			}
+			gotNodes := gotNodesList.Items
+
+			// Compare the expected nodes with the got ones to assess the test outcome
+			if !equality.Semantic.DeepEqual(tc.expectedNodes, gotNodes) {
+				t.Fatalf("Expected nodes don't match got ones\n\n\texpected: %#+v\n\n\tgot:"+
+					" %#+v\n\n", tc.expectedNodes, gotNodes)
+			}
+		})
+	}
+}
+
+func TestUnlabelAllListFails(t *testing.T) {
+	t.Parallel()
+
+	keysOfLabelsToRemove := []string{"a8s.key1"}
+	inputNode := newNode(withName("n1"), withLabels(map[string]string{"a8s.key1": "val1"}))
+
+	// Prepare a fake K8s client that is sabotaged to return an error on LIST API calls.
+	sabotagedK8sClient := fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{inputNode}})
+	listSabotager := func(k8stest.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("dummy error")
+	}
+	sabotagedK8sClient.PrependReactor("list", "nodes", listSabotager)
+
+	// Set up the object under test with the sabotaged K8s client
+	nodes := node.Client{
+		Nodes:            sabotagedK8sClient.CoreV1().Nodes(),
+		MasterNodeTaints: node.MasterTaintKeys,
+	}
+
+	// Invoke the method under test
+	err := nodes.UnlabelAll(context.Background(), keysOfLabelsToRemove)
+
+	if err == nil {
+		t.Fatal("UnlabelAll returned <nil> error, expected non-nil error")
+	}
+
+	if !strings.Contains(err.Error(), "dummy error") {
+		t.Fatalf("Got error \"%s\" must contain message of injected error "+
+			"\"dummy error\" but it doesn't", err.Error())
+	}
+}
+
+func TestUnlabelAllUpdateFails(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		keysOfLabelsToRemove []string
+		inputNodes           []v1.Node
+		expectedNodes        []v1.Node
+		// this is a hash map rather than a slice to make it easy to verify if a node's update
+		// should fail with `nodesWhoseUpdateFails[nodeName]`
+		nodesWhoseUpdateFails map[string]struct{}
+	}{
+		"no_node_is_updated_because_updating_fails_for_all_nodes": {
+			keysOfLabelsToRemove: []string{"a8s.key1"},
+			inputNodes: []v1.Node{
+				newNode(withName("n1"), withLabels(map[string]string{"a8s.key1": "val1"})),
+				newNode(withName("n2"), withLabels(map[string]string{"a8s.key1": "val1"})),
+			},
+			expectedNodes: []v1.Node{
+				newNode(withName("n1"), withLabels(map[string]string{"a8s.key1": "val1"})),
+				newNode(withName("n2"), withLabels(map[string]string{"a8s.key1": "val1"})),
+			},
+			nodesWhoseUpdateFails: map[string]struct{}{
+				"n1": {},
+				"n2": {},
+			},
+		},
+
+		"only_1_node_out_of_3_is_updated_because_updating_the_others_fails": {
+			keysOfLabelsToRemove: []string{"a8s.key1"},
+			inputNodes: []v1.Node{
+				newNode(withName("n1"), withLabels(map[string]string{"a8s.key1": "val1"})),
+				newNode(withName("n2"), withLabels(map[string]string{"a8s.key1": "val1"})),
+				newNode(withName("n3"), withLabels(map[string]string{"a8s.key1": "val1"})),
+			},
+			expectedNodes: []v1.Node{
+				newNode(withName("n1"), withLabels(nil)),
+				newNode(withName("n2"), withLabels(map[string]string{"a8s.key1": "val1"})),
+				newNode(withName("n3"), withLabels(map[string]string{"a8s.key1": "val1"})),
+			},
+			nodesWhoseUpdateFails: map[string]struct{}{
+				"n2": {},
+				"n3": {},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// Rebind tc into this lexical scope. Details on the why at
+			// https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
+			tc := tc
+
+			t.Parallel()
+
+			// Define a function that will intercept the K8s Update API calls on the nodes whose
+			// update must fail in the test case and makes them fail by returning an error.
+			testErr := errors.New("dummy error")
+			updateSabotager := func(apiCall k8stest.Action) (bool, runtime.Object, error) {
+				updatedNode := apiCall.(k8stest.UpdateAction).GetObject().(*v1.Node)
+				if _, mustFail := tc.nodesWhoseUpdateFails[updatedNode.Name]; mustFail {
+					return true, nil, testErr
+				}
+				return false, nil, nil
+			}
+
+			// Prepare a fake K8s client that is sabotaged to return an error on the update of
+			// certain nodes via the function defined right above.
+			sabotagedK8sClient := fake.NewSimpleClientset(&v1.NodeList{Items: tc.inputNodes})
+			sabotagedK8sClient.PrependReactor("update", "nodes", updateSabotager)
+			k8sAPINodesClient := sabotagedK8sClient.CoreV1().Nodes()
+
+			// Set up the object under test with the sabotaged K8s client
+			nodes := node.Client{
+				Nodes:            k8sAPINodesClient,
+				MasterNodeTaints: node.MasterTaintKeys,
+			}
+
+			// Invoke method under test
+			err := nodes.UnlabelAll(context.Background(), tc.keysOfLabelsToRemove)
+
+			if err == nil {
+				t.Fatal("UnlabelAll returned <nil> error, expected non-nil error")
+			}
+
+			// Verify that the error message of every update that failed is mentioned in the error
+			// returned by UnlabelAll
+			individualUpdateErrsCount := strings.Count(err.Error(), testErr.Error())
+			if individualUpdateErrsCount != len(tc.nodesWhoseUpdateFails) {
+				t.Fatalf("Got error \"%s\" must report the error message of every update that "+
+					"failed, but it doesn't: %d updates should have failed but it reports the "+
+					"error messages of %d", err.Error(), len(tc.nodesWhoseUpdateFails),
+					individualUpdateErrsCount)
+			}
+
+			for nodeName := range tc.nodesWhoseUpdateFails {
+				if !strings.Contains(err.Error(), nodeName) {
+					t.Fatalf("Got error \"%s\" must report the name of each node whose update "+
+						"failed and it doesn't: update of %s should have failed but %s is not "+
+						"contained in the error message", err.Error(), nodeName, nodeName)
+				}
+			}
+
+			// Get the nodes after invoking the method under test
+			gotNodesList, err := k8sAPINodesClient.List(context.Background(), metav1.ListOptions{})
+			if err != nil {
+				t.Fatal("Expected no error when listing nodes, got:", err)
+			}
+			gotNodes := gotNodesList.Items
+
+			// Compare the expected nodes with the got ones to ensure that only those whose update
+			// didn't fail changed.
+			if !equality.Semantic.DeepEqual(tc.expectedNodes, gotNodes) {
+				t.Fatalf("Expected nodes don't match got ones\n\n\texpected: %#+v\n\n\tgot:"+
+					" %#+v\n\n", tc.expectedNodes, gotNodes)
+			}
+		})
+	}
+}
+
+func TestTaintWorkersHappyPaths(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
@@ -442,8 +1211,8 @@ func TestTaintAllHappyPaths(t *testing.T) {
 			}
 
 			// Invoke method under test
-			if err := nodes.TaintAll(context.Background(), tc.taintsToAdd); err != nil {
-				t.Fatal("Expected no error when invoking TaintAll, got:", err)
+			if err := nodes.TaintWorkers(context.Background(), tc.taintsToAdd); err != nil {
+				t.Fatal("Expected no error when invoking TaintWorkers, got:", err)
 			}
 
 			// Get the nodes after invoking the method under test
@@ -846,6 +1615,12 @@ func withName(name string) func(*v1.Node) {
 func withTaints(t []v1.Taint) func(*v1.Node) {
 	return func(n *v1.Node) {
 		n.Spec.Taints = t
+	}
+}
+
+func withLabels(labels map[string]string) func(*v1.Node) {
+	return func(n *v1.Node) {
+		n.Labels = labels
 	}
 }
 

--- a/test/integration/topology_awareness/interfaces.go
+++ b/test/integration/topology_awareness/interfaces.go
@@ -6,7 +6,24 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+type NodesClient interface {
+	NodesLister
+	NodesTainter
+	NodesLabeler
+}
+
+type NodesLister interface {
+	ListAll(context.Context) ([]corev1.Node, error)
+	ListWorkers(context.Context) ([]corev1.Node, error)
+}
+
 type NodesTainter interface {
-	TaintAll(context.Context, []corev1.Taint) error
+	TaintWorkers(context.Context, []corev1.Taint) error
 	UntaintAll(context.Context, []corev1.Taint) error
+}
+
+type NodesLabeler interface {
+	Label(ctx context.Context, node corev1.Node, labels map[string]string) error
+	UnlabelAll(ctx context.Context, keysOfLabelsToRemove []string) error
+	GetLabels(ctx context.Context, node string) (map[string]string, error)
 }

--- a/test/integration/topology_awareness/object.go
+++ b/test/integration/topology_awareness/object.go
@@ -11,6 +11,7 @@ type Object interface {
 	dsi.StatefulSetGetter
 	dsi.PodsGetter
 	dsi.TolerationsSetter
+	dsi.WithPodAntiAffinity
 }
 
 func newDSI(ds, namespace, name string, replicas int32) (Object, error) {

--- a/test/integration/topology_awareness/topology_awareness_test.go
+++ b/test/integration/topology_awareness/topology_awareness_test.go
@@ -2,12 +2,14 @@ package topology_awareness
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/anynines/a8s-deployment/test/integration/framework"
@@ -23,6 +25,9 @@ import (
 // TODO: Test adding tolerations to an existing DSI.
 // TODO: Test horizontal scale up.
 // TODO: Test cases where only a subset of nodes is tainted.
+// TODO: Test cases where we update affinity and anti-affinity.
+// TODO: Test cases with anti-affinity and upscaling.
+// TODO: Test cases with pod-affinity and upscaling.
 
 const (
 	suffixLength = 5
@@ -32,23 +37,27 @@ const (
 	instancePort = 5432
 
 	taintingTimeout = 15 * time.Second
+	labelingTimeout = 15 * time.Second
 )
 
-var _ = Describe("DSI tolerations to K8s nodes taints", func() {
+var _ = Describe("DSIs topology awareness", func() {
+	var (
+		err error
+		ctx context.Context
+
+		instance       Object
+		instanceNSN    string
+		instanceClient dsi.DSIClient
+
+		sb            *sbv1alpha1.ServiceBinding
+		sbCredentials secret.SecretData
+
+		portForwardStopCh chan struct{}
+		localPort         int
+	)
+
 	Context("DSI has tolerations to node taints", func() {
 		var (
-			err error
-
-			instance       Object
-			instanceNSN    string
-			instanceClient dsi.DSIClient
-
-			sb            *sbv1alpha1.ServiceBinding
-			sbCredentials secret.SecretData
-
-			portForwardStopCh chan struct{}
-			localPort         int
-
 			taints      []corev1.Taint
 			tolerations []corev1.Toleration
 		)
@@ -88,8 +97,9 @@ var _ = Describe("DSI tolerations to K8s nodes taints", func() {
 					},
 				}
 
-				Eventually(func() error { return nodes.TaintAll(ctx, taints) }, taintingTimeout).
-					Should(Succeed(), "failed to taint nodes")
+				Eventually(func() error {
+					return nodes.TaintWorkers(ctx, taints)
+				}, taintingTimeout).Should(Succeed())
 			})
 
 			It("Implements a 1-replica DSI that tolerates the node taint", func() {
@@ -279,8 +289,9 @@ var _ = Describe("DSI tolerations to K8s nodes taints", func() {
 					},
 				}
 
-				Eventually(func() error { return nodes.TaintAll(ctx, taints) }, taintingTimeout).
-					Should(Succeed(), "failed to taint nodes")
+				Eventually(func() error {
+					return nodes.TaintWorkers(ctx, taints)
+				}, taintingTimeout).Should(Succeed())
 			})
 
 			It("Implements a 1-replica DSI that tolerates the node taints", func() {
@@ -442,4 +453,328 @@ var _ = Describe("DSI tolerations to K8s nodes taints", func() {
 			})
 		})
 	})
+
+	Context("DSI pods have anti-affinity rules to repel each other", func() {
+		const (
+			a8sTestNodeLabelKey = "a8s-test-host"
+			a8sTestAZLabelKey   = "a8s-test-az"
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+		})
+
+		AfterEach(func() {
+			Eventually(func() error {
+				return nodes.UnlabelAll(ctx, []string{a8sTestNodeLabelKey, a8sTestAZLabelKey})
+			}).Should(Succeed())
+
+			close(portForwardStopCh)
+
+			Expect(k8sClient.Delete(ctx, sb)).To(Succeed(),
+				"failed to delete DSI "+instanceNSN+"'s ServiceBinding")
+
+			Expect(k8sClient.Delete(ctx, instance.GetClientObject())).To(Succeed(),
+				"failed to delete DSI "+instanceNSN)
+		})
+
+		Context("3-replica DSI with each replica in a different AZ", func() {
+			numAZs := 3
+
+			BeforeEach(func() {
+				Eventually(func(g Gomega) {
+					var k8sNodes []corev1.Node
+					k8sNodes, err = nodes.ListWorkers(ctx)
+					g.Expect(err).To(BeNil())
+
+					for i, n := range k8sNodes {
+						az := "az-" + strconv.Itoa(i%numAZs)
+						labelToAdd := map[string]string{a8sTestAZLabelKey: az}
+						g.Expect(nodes.Label(ctx, n, labelToAdd)).To(Succeed())
+					}
+				}).Should(Succeed(), labelingTimeout)
+			})
+
+			It("Implements a 3-replica DSI where each replica is in a different AZ", func() {
+				replicas := int32(3)
+
+				By("Accepting the creation of the DSI API object", func() {
+					// Create the DSI K8s API object
+					instance, err = newDSI(dataservice, testingNamespace,
+						framework.GenerateName(instanceNamePrefix, GinkgoParallelProcess(),
+							suffixLength), replicas)
+					Expect(err).To(BeNil(), "failed to generate DSI object")
+
+					instance.AddRequiredPodAntiAffinityTerm(corev1.PodAffinityTerm{
+						TopologyKey: a8sTestAZLabelKey,
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"a8s.a9s/dsi-name": instance.GetName(),
+								"a8s.a9s/dsi-kind": instance.
+									GetObjectKind().
+									GroupVersionKind().
+									Kind,
+							},
+						},
+					})
+
+					instanceNSN = instance.GetNamespace() + "/" + instance.GetName()
+					Expect(k8sClient.Create(ctx, instance.GetClientObject())).To(Succeed(),
+						"failed to create DSI "+instanceNSN)
+				})
+
+				By("Getting the DSI up and running", func() {
+					dsi.WaitForReadiness(ctx, instance.GetClientObject(), k8sClient)
+				})
+
+				By("Placing the Pods on nodes in different AZs", func() {
+					pods, err := instance.Pods(ctx, k8sClient)
+					Expect(err).To(BeNil())
+					Expect(verifyDSIPodsAreInDifferentAZs(ctx, pods, a8sTestAZLabelKey)).
+						To(Succeed())
+				})
+
+				By("Accepting a ServiceBinding to the DSI", func() {
+					sb = servicebinding.New(
+						servicebinding.SetNamespacedName(instance.GetClientObject()),
+						servicebinding.SetInstanceRef(instance.GetClientObject()),
+					)
+					Expect(k8sClient.Create(ctx, sb)).To(Succeed(),
+						"failed to create ServiceBinding for DSI "+instanceNSN)
+				})
+
+				By("Marking the ServiceBinding as implemented", func() {
+					Eventually(func(g Gomega) {
+						sbNSN := types.NamespacedName{Namespace: sb.Namespace, Name: sb.Name}
+						g.Expect(k8sClient.Get(ctx, sbNSN, sb)).
+							To(Succeed(), "failed to get DSI "+instanceNSN+"'s ServiceBinding")
+						g.Expect(sb.Status.Implemented).
+							To(BeTrue(), "ServiceBinding of DSI "+instanceNSN+" isn't implemented")
+					}, 10*time.Second).Should(Succeed(),
+						"failed to verify that the ServiceBinding of DSI "+instanceNSN+
+							" gets implemented")
+				})
+
+				By("Generating a client to the DSI to read/write to/from it", func() {
+					// Get credentials to write to the DSI
+					sbCredentials, err = secret.Data(
+						ctx, k8sClient, servicebinding.SecretName(sb.Name), testingNamespace)
+					Expect(err).To(BeNil(), "failed to parse secret data for ServiceBinding "+
+						sb.GetNamespace()+"/"+sb.GetName())
+
+					// Create a portforwarding to write to the DSI from out of cluster
+					portForwardStopCh, localPort, err = framework.PortForward(
+						ctx, instancePort, kubeconfigPath, instance, k8sClient)
+					Expect(err).To(BeNil(), "failed to establish portforward to DSI "+instanceNSN)
+
+					// Generate a client to the DSI using the credentials and the portforwarding
+					instanceClient, err = dsi.NewClient(dataservice,
+						strconv.Itoa(localPort),
+						sbCredentials)
+					Expect(err).To(BeNil(), "failed to create client to DSI "+instanceNSN)
+				})
+
+				By("Setting up the DSI so that clients can write/read data into/from it", func() {
+					Expect(instanceClient.Write(ctx, appsDefaultDB, "sample data")).To(Succeed(),
+						"failed to write into database "+appsDefaultDB+" in DSI "+instanceNSN)
+					readData, err := instanceClient.Read(ctx, appsDefaultDB)
+					Expect(err).To(BeNil(),
+						"failed to read data from database "+appsDefaultDB+" in DSI "+instanceNSN)
+					Expect(readData).To(Equal("sample data"),
+						"data read from database "+appsDefaultDB+" in DSI "+instanceNSN+
+							" doesn't match previously written data")
+				})
+			})
+		})
+
+		Context("3-replica DSI in a cluster with 3 hosts but only 2 AZs", func() {
+			numAZs := 2
+			numNodes := 3
+
+			BeforeEach(func() {
+				Eventually(func(g Gomega) {
+					var k8sNodes []corev1.Node
+					k8sNodes, err = nodes.ListWorkers(ctx)
+					g.Expect(err).To(BeNil())
+
+					for i, n := range k8sNodes {
+						az := "az-" + strconv.Itoa(i%numAZs)
+						node := "node-" + strconv.Itoa(i%numNodes)
+						labelsToAdd := map[string]string{
+							a8sTestAZLabelKey:   az,
+							a8sTestNodeLabelKey: node,
+						}
+						g.Expect(nodes.Label(ctx, n, labelsToAdd)).To(Succeed())
+					}
+				}).Should(Succeed(), labelingTimeout)
+			})
+
+			It("Implements a 3-replica DSI with replicas spread across 3 hosts and 2 AZs", func() {
+				replicas := int32(3)
+
+				By("Accepting the creation of the DSI API object", func() {
+					// Create the DSI K8s API object
+					instance, err = newDSI(dataservice, testingNamespace,
+						framework.GenerateName(instanceNamePrefix, GinkgoParallelProcess(),
+							suffixLength), replicas)
+					Expect(err).To(BeNil(), "failed to generate DSI object")
+
+					instance.AddRequiredPodAntiAffinityTerm(corev1.PodAffinityTerm{
+						TopologyKey: a8sTestNodeLabelKey,
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"a8s.a9s/dsi-name": instance.GetName(),
+								"a8s.a9s/dsi-kind": instance.
+									GetObjectKind().
+									GroupVersionKind().
+									Kind,
+							},
+						},
+					})
+
+					instance.AddPreferredPodAntiAffinityTerm(100, corev1.PodAffinityTerm{
+						TopologyKey: a8sTestAZLabelKey,
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"a8s.a9s/dsi-name": instance.GetName(),
+								"a8s.a9s/dsi-kind": instance.
+									GetObjectKind().
+									GroupVersionKind().
+									Kind,
+							},
+						},
+					})
+
+					instanceNSN = instance.GetNamespace() + "/" + instance.GetName()
+					Expect(k8sClient.Create(ctx, instance.GetClientObject())).To(Succeed(),
+						"failed to create DSI "+instanceNSN)
+				})
+
+				By("Getting the DSI up and running", func() {
+					dsi.WaitForReadiness(ctx, instance.GetClientObject(), k8sClient)
+				})
+
+				By("Placing the Pods on different nodes and not in just one AZ", func() {
+					pods, err := instance.Pods(ctx, k8sClient)
+					Expect(err).To(BeNil())
+					Expect(verifyDSIPodsAreOnDifferentNodes(ctx, pods, a8sTestNodeLabelKey)).
+						To(Succeed())
+					Expect(verifyDSIPodsAreInMoreThanOneAZ(ctx, pods, a8sTestAZLabelKey)).
+						To(Succeed())
+				})
+
+				By("Accepting a ServiceBinding to the DSI", func() {
+					sb = servicebinding.New(
+						servicebinding.SetNamespacedName(instance.GetClientObject()),
+						servicebinding.SetInstanceRef(instance.GetClientObject()),
+					)
+					Expect(k8sClient.Create(ctx, sb)).To(Succeed(),
+						"failed to create ServiceBinding for DSI "+instanceNSN)
+				})
+
+				By("Marking the ServiceBinding as implemented", func() {
+					Eventually(func(g Gomega) {
+						sbNSN := types.NamespacedName{Namespace: sb.Namespace, Name: sb.Name}
+						g.Expect(k8sClient.Get(ctx, sbNSN, sb)).
+							To(Succeed(), "failed to get DSI "+instanceNSN+"'s ServiceBinding")
+						g.Expect(sb.Status.Implemented).
+							To(BeTrue(), "ServiceBinding of DSI "+instanceNSN+" isn't implemented")
+					}, 10*time.Second).Should(Succeed(),
+						"failed to verify that the ServiceBinding of DSI "+instanceNSN+
+							" gets implemented")
+				})
+
+				By("Generating a client to the DSI to read/write to/from it", func() {
+					// Get credentials to write to the DSI
+					sbCredentials, err = secret.Data(
+						ctx, k8sClient, servicebinding.SecretName(sb.Name), testingNamespace)
+					Expect(err).To(BeNil(), "failed to parse secret data for ServiceBinding "+
+						sb.GetNamespace()+"/"+sb.GetName())
+
+					// Create a portforwarding to write to the DSI from out of cluster
+					portForwardStopCh, localPort, err = framework.PortForward(
+						ctx, instancePort, kubeconfigPath, instance, k8sClient)
+					Expect(err).To(BeNil(), "failed to establish portforward to DSI "+instanceNSN)
+
+					// Generate a client to the DSI using the credentials and the portforwarding
+					instanceClient, err = dsi.NewClient(dataservice,
+						strconv.Itoa(localPort),
+						sbCredentials)
+					Expect(err).To(BeNil(), "failed to create client to DSI "+instanceNSN)
+				})
+
+				By("Setting up the DSI so that clients can write/read data into/from it", func() {
+					Expect(instanceClient.Write(ctx, appsDefaultDB, "sample data")).To(Succeed(),
+						"failed to write into database "+appsDefaultDB+" in DSI "+instanceNSN)
+					readData, err := instanceClient.Read(ctx, appsDefaultDB)
+					Expect(err).To(BeNil(),
+						"failed to read data from database "+appsDefaultDB+" in DSI "+instanceNSN)
+					Expect(readData).To(Equal("sample data"),
+						"data read from database "+appsDefaultDB+" in DSI "+instanceNSN+
+							" doesn't match previously written data")
+				})
+			})
+		})
+	})
+
 })
+
+func verifyDSIPodsAreInDifferentAZs(ctx context.Context,
+	dsiPods []corev1.Pod,
+	azLabelKey string) error {
+
+	return verifyDSIPodsAreInDifferentTopologyDomains(ctx, dsiPods, "AZ", azLabelKey)
+}
+
+func verifyDSIPodsAreOnDifferentNodes(ctx context.Context,
+	dsiPods []corev1.Pod,
+	nodeLabelKey string) error {
+
+	return verifyDSIPodsAreInDifferentTopologyDomains(ctx, dsiPods, "node", nodeLabelKey)
+}
+
+func verifyDSIPodsAreInDifferentTopologyDomains(ctx context.Context,
+	dsiPods []corev1.Pod,
+	topologyDomainName, topologyDomainKey string) error {
+
+	domainToPod := map[string]string{}
+	for _, p := range dsiPods {
+		podNodeLabels, err := nodes.GetLabels(ctx, p.Spec.NodeName)
+		if err != nil {
+			return fmt.Errorf("failed to verify that all dsi pods are in different %ss: %w",
+				topologyDomainName, err)
+		}
+
+		podDomain := podNodeLabels[topologyDomainKey]
+		if otherPodInDomain := domainToPod[podDomain]; otherPodInDomain != "" {
+			return fmt.Errorf("all dsi pods should be in different %ss but pods %s and %s are "+
+				"both in %s %s", topologyDomainName, p.Name, otherPodInDomain, topologyDomainName,
+				podDomain)
+		}
+		domainToPod[podDomain] = p.Name
+	}
+
+	return nil
+}
+
+func verifyDSIPodsAreInMoreThanOneAZ(ctx context.Context,
+	dsiPods []corev1.Pod,
+	azLabelKey string) error {
+
+	seenAZs := map[string]struct{}{}
+	podAZ := ""
+	for _, p := range dsiPods {
+		podNodeLabels, err := nodes.GetLabels(ctx, p.Spec.NodeName)
+		if err != nil {
+			return fmt.Errorf("failed to verify that dsi pods are in more than one AZ: %w", err)
+		}
+
+		podAZ = podNodeLabels[azLabelKey]
+		seenAZs[podAZ] = struct{}{}
+		if len(seenAZs) > 1 {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("all dsi pods are in AZ %s when they should be in more than one AZ", podAZ)
+}


### PR DESCRIPTION
# Short Description

Add functionality to label and unlabel nodes to the test framework as the topology awareness tests need to label and unlabel nodes.


# Checks
- [x] Commit message adheres to our [guideline](https://anynines.atlassian.net/wiki/spaces/DS/pages/2423193626/Version+Control+Workflow)
