### PR TITLE
Add functions to list all nodes and worker nodes

### DIFF
--- a/test/integration/framework/dsi/dsi.go
+++ b/test/integration/framework/dsi/dsi.go
@@ -36,6 +36,11 @@ type TolerationsSetter interface {
 	SetTolerations(...corev1.Toleration)
 }
 
+type WithPodAntiAffinity interface {
+	AddRequiredPodAntiAffinityTerm(antiAffinityTerm corev1.PodAffinityTerm)
+	AddPreferredPodAntiAffinityTerm(weight int, antiAffinityTerm corev1.PodAffinityTerm)
+}
+
 type StatefulSetGetter interface {
 	StatefulSet(context.Context, runtimeClient.Client) (*appsv1.StatefulSet, error)
 }

--- a/test/integration/framework/node/client_test.go
+++ b/test/integration/framework/node/client_test.go
@@ -3,7 +3,6 @@ package node_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"sort"
 	"strings"
@@ -305,615 +304,16 @@ func TestListWorkersFails(t *testing.T) {
 	}
 }
 
-func TestLabelWorkersHappyPaths(t *testing.T) {
-	t.Parallel()
-
-	testCases := map[string]struct {
-		labelsToAdd   map[string]string
-		inputNodes    []v1.Node
-		expectedNodes []v1.Node
-	}{
-		"1_label_is_added_to_1_node_with_nil_labels": {
-			labelsToAdd: map[string]string{"a8s.key1": "val1"},
-			inputNodes:  []v1.Node{newNode(withName("n1"), withLabels(nil))},
-			expectedNodes: []v1.Node{
-				newNode(
-					withName("n1"),
-					withLabels(map[string]string{"a8s.key1": "val1"}),
-				),
-			},
-		},
-
-		"2_labels_are_added_to_1_node_with_empty_labels": {
-			labelsToAdd: map[string]string{
-				"a8s.key1": "val1",
-				"a8s.key2": "val2",
-			},
-			inputNodes: []v1.Node{newNode(withName("n1"), withLabels(map[string]string{}))},
-			expectedNodes: []v1.Node{
-				newNode(
-					withName("n1"),
-					withLabels(map[string]string{
-						"a8s.key1": "val1",
-						"a8s.key2": "val2",
-					}),
-				),
-			},
-		},
-
-		"1_label_is_added_to_3_nodes_with_no_or_different_labels": {
-			labelsToAdd: map[string]string{"a8s.key1": "val1"},
-			inputNodes: []v1.Node{
-				newNode(
-					withName("n1"),
-					withLabels(map[string]string{}),
-				),
-				newNode(
-					withName("n2"),
-					withLabels(map[string]string{"key10": "val10"}),
-				),
-				newNode(
-					withName("n3"),
-					withLabels(map[string]string{
-						"key10": "val10",
-						"key20": "val20",
-					}),
-				),
-			},
-			expectedNodes: []v1.Node{
-				newNode(
-					withName("n1"),
-					withLabels(map[string]string{"a8s.key1": "val1"}),
-				),
-				newNode(
-					withName("n2"),
-					withLabels(map[string]string{
-						"key10":    "val10",
-						"a8s.key1": "val1",
-					}),
-				),
-				newNode(
-					withName("n3"),
-					withLabels(map[string]string{
-						"key10":    "val10",
-						"key20":    "val20",
-						"a8s.key1": "val1",
-					}),
-				),
-			},
-		},
-
-		"2_labels_are_added_to_3_nodes_with_no_or_different_labels": {
-			labelsToAdd: map[string]string{
-				"a8s.key1": "val1",
-				"a8s.key2": "val2",
-			},
-			inputNodes: []v1.Node{
-				newNode(
-					withName("n1"),
-					withLabels(nil),
-				),
-				newNode(
-					withName("n2"),
-					withLabels(map[string]string{"key10": "val10"}),
-				),
-				newNode(
-					withName("n3"),
-					withLabels(map[string]string{
-						"key10": "val10",
-						"key20": "val20",
-					}),
-				),
-			},
-			expectedNodes: []v1.Node{
-				newNode(
-					withName("n1"),
-					withLabels(map[string]string{
-						"a8s.key1": "val1",
-						"a8s.key2": "val2",
-					}),
-				),
-				newNode(
-					withName("n2"),
-					withLabels(map[string]string{
-						"key10":    "val10",
-						"a8s.key1": "val1",
-						"a8s.key2": "val2",
-					}),
-				),
-				newNode(
-					withName("n3"),
-					withLabels(map[string]string{
-						"key10":    "val10",
-						"key20":    "val20",
-						"a8s.key1": "val1",
-						"a8s.key2": "val2",
-					}),
-				),
-			},
-		},
-
-		"2_labels_to_2_nodes_that_already_have_them": {
-			labelsToAdd: map[string]string{
-				"a8s.key1": "val1",
-				"a8s.key2": "val2",
-			},
-			inputNodes: []v1.Node{
-				newNode(
-					withName("n1"),
-					withLabels(map[string]string{
-						"a8s.key1": "val1",
-						"a8s.key2": "val2",
-					}),
-				),
-				newNode(
-					withName("n2"),
-					withLabels(map[string]string{
-						"a8s.key1": "val1",
-						"a8s.key2": "val2",
-						"key10":    "val10",
-					}),
-				),
-			},
-			expectedNodes: []v1.Node{
-				newNode(
-					withName("n1"),
-					withLabels(map[string]string{
-						"a8s.key1": "val1",
-						"a8s.key2": "val2",
-					}),
-				),
-				newNode(
-					withName("n2"),
-					withLabels(map[string]string{
-						"a8s.key1": "val1",
-						"a8s.key2": "val2",
-						"key10":    "val10",
-					}),
-				),
-			},
-		},
-
-		"2_labels_to_2_nodes_that_have_only_1_of_the_2_labels": {
-			labelsToAdd: map[string]string{
-				"a8s.key1": "val1",
-				"a8s.key2": "val2",
-			},
-			inputNodes: []v1.Node{
-				newNode(
-					withName("n1"),
-					withLabels(map[string]string{"a8s.key1": "val1"}),
-				),
-				newNode(
-					withName("n2"),
-					withLabels(map[string]string{
-						"a8s.key2": "val2",
-						"key10":    "val10",
-					}),
-				),
-			},
-			expectedNodes: []v1.Node{
-				newNode(
-					withName("n1"),
-					withLabels(map[string]string{
-						"a8s.key1": "val1",
-						"a8s.key2": "val2",
-					}),
-				),
-				newNode(
-					withName("n2"),
-					withLabels(map[string]string{
-						"a8s.key1": "val1",
-						"a8s.key2": "val2",
-						"key10":    "val10",
-					}),
-				),
-			},
-		},
-
-		"2_labels_are_not_added_to_nodes_with_control_taint": {
-			labelsToAdd: map[string]string{
-				"a8s.key1": "val1",
-				"a8s.key2": "val2",
-			},
-			inputNodes: []v1.Node{
-				newNode(
-					withName("n1"),
-					withLabels(nil),
-					withTaints([]v1.Taint{
-						{Key: "node-role.kubernetes.io/control-plane", Effect: "NoSchedule"},
-					}),
-				),
-				newNode(
-					withName("n2"),
-					withLabels(map[string]string{"key10": "val10"}),
-					withTaints([]v1.Taint{
-						{Key: "node-role.kubernetes.io/control-plane", Effect: "NoExecute"},
-					}),
-				),
-			},
-			expectedNodes: []v1.Node{
-				newNode(
-					withName("n1"),
-					withLabels(nil),
-					withTaints([]v1.Taint{
-						{Key: "node-role.kubernetes.io/control-plane", Effect: "NoSchedule"},
-					}),
-				),
-				newNode(
-					withName("n2"),
-					withLabels(map[string]string{"key10": "val10"}),
-					withTaints([]v1.Taint{
-						{Key: "node-role.kubernetes.io/control-plane", Effect: "NoExecute"},
-					}),
-				),
-			},
-		},
-
-		"1_label_is_not_added_to_nodes_with_master_taint": {
-			labelsToAdd: map[string]string{"a8s.key1": "val1"},
-			inputNodes: []v1.Node{
-				newNode(
-					withName("n1"),
-					withLabels(nil),
-					withTaints([]v1.Taint{
-						{Key: "node-role.kubernetes.io/master", Effect: "NoSchedule"},
-					}),
-				),
-				newNode(
-					withName("n2"),
-					withLabels(map[string]string{"key10": "val10"}),
-					withTaints([]v1.Taint{
-						{Key: "node-role.kubernetes.io/master", Effect: "NoExecute"},
-					}),
-				),
-			},
-			expectedNodes: []v1.Node{
-				newNode(
-					withName("n1"),
-					withLabels(nil),
-					withTaints([]v1.Taint{
-						{Key: "node-role.kubernetes.io/master", Effect: "NoSchedule"},
-					}),
-				),
-				newNode(
-					withName("n2"),
-					withLabels(map[string]string{"key10": "val10"}),
-					withTaints([]v1.Taint{
-						{Key: "node-role.kubernetes.io/master", Effect: "NoExecute"},
-					}),
-				),
-			},
-		},
-
-		"1_label_is_added_to_normal_nodes_but_not_to_control_plane_nodes": {
-			labelsToAdd: map[string]string{"a8s.key1": "val1"},
-			inputNodes: []v1.Node{
-				newNode(
-					withName("n1"),
-					withLabels(map[string]string{"key10": "val10"}),
-				),
-				newNode(
-					withName("n2"),
-					withLabels(map[string]string{"key10": "val10"}),
-					withTaints([]v1.Taint{
-						{Key: "node-role.kubernetes.io/control-plane", Effect: "NoExecute"},
-					}),
-				),
-			},
-			expectedNodes: []v1.Node{
-				newNode(
-					withName("n1"),
-					withLabels(map[string]string{
-						"key10":    "val10",
-						"a8s.key1": "val1",
-					}),
-				),
-				newNode(
-					withName("n2"),
-					withLabels(map[string]string{"key10": "val10"}),
-					withTaints([]v1.Taint{
-						{Key: "node-role.kubernetes.io/control-plane", Effect: "NoExecute"},
-					}),
-				),
-			},
-		},
-
-		"1_label_is_added_to_normal_nodes_but_not_to_master_nodes": {
-			labelsToAdd: map[string]string{"a8s.key1": "val1"},
-			inputNodes: []v1.Node{
-				newNode(
-					withName("n1"),
-					withLabels(map[string]string{"key10": "val10"}),
-				),
-				newNode(
-					withName("n2"),
-					withLabels(map[string]string{"key10": "val10"}),
-					withTaints([]v1.Taint{
-						{Key: "node-role.kubernetes.io/master", Effect: "NoExecute"},
-					}),
-				),
-			},
-			expectedNodes: []v1.Node{
-				newNode(
-					withName("n1"),
-					withLabels(map[string]string{
-						"key10":    "val10",
-						"a8s.key1": "val1",
-					}),
-				),
-				newNode(
-					withName("n2"),
-					withLabels(map[string]string{"key10": "val10"}),
-					withTaints([]v1.Taint{
-						{Key: "node-role.kubernetes.io/master", Effect: "NoExecute"},
-					}),
-				),
-			},
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			// Rebind tc into this lexical scope. Details on the why at
-			// https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
-			tc := tc
-
-			t.Parallel()
-
-			// Set up object under test
-			k8sAPINodesClient := fake.
-				NewSimpleClientset(&v1.NodeList{Items: tc.inputNodes}).
-				CoreV1().
-				Nodes()
-			nodes := node.Client{
-				Nodes:            k8sAPINodesClient,
-				MasterNodeTaints: node.MasterTaintKeys,
-			}
-
-			// Invoke method under test
-			if err := nodes.LabelWorkers(context.Background(), tc.labelsToAdd); err != nil {
-				t.Fatal("Expected no error when invoking LabelWorkers, got:", err)
-			}
-
-			// Get the nodes after invoking the method under test
-			gotNodesList, err := k8sAPINodesClient.List(context.Background(), metav1.ListOptions{})
-			if err != nil {
-				t.Fatal("Expected no error when listing nodes, got:", err)
-			}
-			gotNodes := gotNodesList.Items
-
-			// Compare the expected nodes with the got ones to assess the test outcome
-			if !equality.Semantic.DeepEqual(tc.expectedNodes, gotNodes) {
-				t.Fatalf("Expected nodes don't match got ones\n\n\texpected: %#+v\n\n\tgot:"+
-					" %#+v\n\n", tc.expectedNodes, gotNodes)
-			}
-		})
-	}
-}
-
-func TestLabelWorkersListFails(t *testing.T) {
-	t.Parallel()
-
-	labelsToAdd := map[string]string{"a8s.key1": "val1"}
-	inputNode := newNode(withName("n1"), withLabels(nil))
-
-	// Prepare a fake K8s client that is sabotaged to return an error on LIST API calls.
-	sabotagedK8sClient := fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{inputNode}})
-	listSabotager := func(k8stest.Action) (bool, runtime.Object, error) {
-		return true, nil, errors.New("dummy error")
-	}
-	sabotagedK8sClient.PrependReactor("list", "nodes", listSabotager)
-
-	// Set up the object under test with the sabotaged K8s client
-	nodes := node.Client{
-		Nodes:            sabotagedK8sClient.CoreV1().Nodes(),
-		MasterNodeTaints: node.MasterTaintKeys,
-	}
-
-	// Invoke the method under test
-	err := nodes.LabelWorkers(context.Background(), labelsToAdd)
-
-	if err == nil {
-		t.Fatal("LabelWorkers returned <nil> error, expected non-nil error")
-	}
-
-	if !strings.Contains(err.Error(), "dummy error") {
-		t.Fatalf("Got error \"%s\" must contain message of injected error "+
-			"\"dummy error\" but it doesn't", err.Error())
-	}
-}
-
-func TestLabelWorkersUpdateFails(t *testing.T) {
-	t.Parallel()
-
-	testCases := map[string]struct {
-		labelsToAdd   map[string]string
-		inputNodes    []v1.Node
-		expectedNodes []v1.Node
-		// this is a hash map rather than a slice to make it easy to verify if a node's update
-		// should fail with `nodesWhoseUpdateFails[nodeName]`
-		nodesWhoseUpdateFails map[string]struct{}
-	}{
-		"no_node_is_updated_because_updating_fails_for_all_nodes": {
-			labelsToAdd: map[string]string{"a8s.key1": "val1"},
-			inputNodes: []v1.Node{
-				newNode(withName("n1"), withLabels(nil)),
-				newNode(withName("n2"), withLabels(nil)),
-			},
-			expectedNodes: []v1.Node{
-				newNode(withName("n1"), withLabels(nil)),
-				newNode(withName("n2"), withLabels(nil)),
-			},
-			nodesWhoseUpdateFails: map[string]struct{}{
-				"n1": {},
-				"n2": {},
-			},
-		},
-
-		"only_1_node_out_of_3_is_updated_because_updating_the_others_fails": {
-			labelsToAdd: map[string]string{"a8s.key1": "val1"},
-			inputNodes: []v1.Node{
-				newNode(withName("n1"), withLabels(nil)),
-				newNode(withName("n2"), withLabels(nil)),
-				newNode(withName("n3"), withLabels(nil)),
-			},
-			expectedNodes: []v1.Node{
-				newNode(withName("n1"), withLabels(map[string]string{"a8s.key1": "val1"})),
-				newNode(withName("n2"), withLabels(nil)),
-				newNode(withName("n3"), withLabels(nil)),
-			},
-			nodesWhoseUpdateFails: map[string]struct{}{
-				"n2": {},
-				"n3": {},
-			},
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			// Rebind tc into this lexical scope. Details on the why at
-			// https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
-			tc := tc
-
-			t.Parallel()
-
-			// Define a function that will intercept the K8s Update API calls on the nodes whose
-			// update must fail in the test case and makes them fail by returning an error.
-			testErr := errors.New("dummy error")
-			updateSabotager := func(apiCall k8stest.Action) (bool, runtime.Object, error) {
-				updatedNode := apiCall.(k8stest.UpdateAction).GetObject().(*v1.Node)
-				if _, mustFail := tc.nodesWhoseUpdateFails[updatedNode.Name]; mustFail {
-					return true, nil, testErr
-				}
-				return false, nil, nil
-			}
-
-			// Prepare a fake K8s client that is sabotaged to return an error on the update of
-			// certain nodes via the function defined right above.
-			sabotagedK8sClient := fake.NewSimpleClientset(&v1.NodeList{Items: tc.inputNodes})
-			sabotagedK8sClient.PrependReactor("update", "nodes", updateSabotager)
-			k8sAPINodesClient := sabotagedK8sClient.CoreV1().Nodes()
-
-			// Set up the object under test with the sabotaged K8s client
-			nodes := node.Client{
-				Nodes:            k8sAPINodesClient,
-				MasterNodeTaints: node.MasterTaintKeys,
-			}
-
-			// Invoke method under test
-			err := nodes.LabelWorkers(context.Background(), tc.labelsToAdd)
-
-			if err == nil {
-				t.Fatal("LabelWorkers returned <nil> error, expected non-nil error")
-			}
-
-			// Verify that the error message of every update that failed is mentioned in the error
-			// returned by LabelAll
-			individualUpdateErrsCount := strings.Count(err.Error(), testErr.Error())
-			if individualUpdateErrsCount != len(tc.nodesWhoseUpdateFails) {
-				t.Fatalf("Got error \"%s\" must report the error message of every update that "+
-					"failed, but it doesn't: %d updates should have failed but it reports the "+
-					"error messages of %d", err.Error(), len(tc.nodesWhoseUpdateFails),
-					individualUpdateErrsCount)
-			}
-
-			for nodeName := range tc.nodesWhoseUpdateFails {
-				if !strings.Contains(err.Error(), nodeName) {
-					t.Fatalf("Got error \"%s\" must report the name of each node whose update "+
-						"failed and it doesn't: update of %s should have failed but %s is not "+
-						"contained in the error message", err.Error(), nodeName, nodeName)
-				}
-			}
-
-			// Get the nodes after invoking the method under test
-			gotNodesList, err := k8sAPINodesClient.List(context.Background(), metav1.ListOptions{})
-			if err != nil {
-				t.Fatal("Expected no error when listing nodes, got:", err)
-			}
-			gotNodes := gotNodesList.Items
-
-			// Compare the expected nodes with the got ones to ensure that only those whose update
-			// didn't fail changed.
-			if !equality.Semantic.DeepEqual(tc.expectedNodes, gotNodes) {
-				t.Fatalf("Expected nodes don't match got ones\n\n\texpected: %#+v\n\n\tgot:"+
-					" %#+v\n\n", tc.expectedNodes, gotNodes)
-			}
-		})
-	}
-}
-
-func TestLabelWorkersPanicsWhenLabelKeyMatchesAndValDoesNot(t *testing.T) {
-	t.Parallel()
-
-	// inputNode has a label with the same key but different value as the label to add, that must
-	// trigger a panic.
-	labelsToAdd := map[string]string{"a8s.key1": "val1"}
-	inputNode := newNode(withName("n1"), withLabels(map[string]string{"a8s.key1": "different-val"}))
-
-	// Set up the object under test.
-	k8sAPINodesClient := fake.
-		NewSimpleClientset(&v1.NodeList{Items: []v1.Node{inputNode}}).
-		CoreV1().
-		Nodes()
-	nodes := node.Client{
-		Nodes:            k8sAPINodesClient,
-		MasterNodeTaints: node.MasterTaintKeys,
-	}
-
-	// Deferred check that the method under test will panic, produce an informative enough message,
-	// and leave the nodes unchanged.
-	defer func() {
-		panicMsg := recover()
-		if panicMsg == nil {
-			t.Fatal("Expected LabelAll to panic, but it didn't")
-		}
-		panicMsgStr := fmt.Sprintf("%#+v", panicMsg)
-		if !strings.Contains(panicMsgStr, "a8s.key1") {
-			t.Fatal("Expected LabelAll panic message to mention the label key, but it didn't")
-		}
-		if !strings.Contains(panicMsgStr, "val1") {
-			t.Fatal("Expected LabelAll panic message to mention the allowed label value, " +
-				"but it didn't")
-		}
-		if !strings.Contains(panicMsgStr, "different-val") {
-			t.Fatal("Expected LabelAll panic message to mention the found label value, " +
-				"but it didn't")
-		}
-
-		// To make sure that the node wasn't updated anyway, we get the nodes after invoking the
-		// method under test.
-		gotNodesList, err := k8sAPINodesClient.List(context.Background(), metav1.ListOptions{})
-		if err != nil {
-			t.Fatal("Expected no error when listing nodes, got:", err)
-		}
-		// We only had one node so we can get it at index 0.
-		gotNode := gotNodesList.Items[0]
-
-		// Compare the input node with the got one to ensure it wasn't updated even if there was a
-		// panic.
-		if !equality.Semantic.DeepEqual(inputNode, gotNode) {
-			t.Fatalf("Expected node doesn't match got one\n\n\texpected: %#+v\n\n\tgot:"+
-				" %#+v\n\n", inputNode, gotNode)
-		}
-	}()
-
-	// Invoke the method under test.
-	if err := nodes.LabelWorkers(context.Background(), labelsToAdd); err != nil {
-		t.Fatal("Expected panic when invoking LabelWorkers, got error instead:", err)
-	}
-}
-
 func TestUnlabelAllHappyPaths(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		labelsToRemove map[string]string
-		inputNodes     []v1.Node
-		expectedNodes  []v1.Node
+		keysOfLabelsToRemove []string
+		inputNodes           []v1.Node
+		expectedNodes        []v1.Node
 	}{
 		"nodes_with_no_labels_are_left_unchanged": {
-			labelsToRemove: map[string]string{"a8s.key1": "val1"},
+			keysOfLabelsToRemove: []string{"a8s.key1"},
 			inputNodes: []v1.Node{
 				newNode(withName("n1"), withLabels(nil)),
 				newNode(withName("n2"), withLabels(map[string]string{})),
@@ -925,7 +325,7 @@ func TestUnlabelAllHappyPaths(t *testing.T) {
 		},
 
 		"1_label_removed_from_1_node_with_no_other_labels": {
-			labelsToRemove: map[string]string{"a8s.key1": "val1"},
+			keysOfLabelsToRemove: []string{"a8s.key1"},
 			inputNodes: []v1.Node{
 				newNode(
 					withName("n1"),
@@ -936,10 +336,7 @@ func TestUnlabelAllHappyPaths(t *testing.T) {
 		},
 
 		"2_labels_removed_from_1_node_with_no_other_labels": {
-			labelsToRemove: map[string]string{
-				"a8s.key1": "val1",
-				"a8s.key2": "val2",
-			},
+			keysOfLabelsToRemove: []string{"a8s.key1", "a8s.key2"},
 			inputNodes: []v1.Node{
 				newNode(
 					withName("n1"),
@@ -953,7 +350,7 @@ func TestUnlabelAllHappyPaths(t *testing.T) {
 		},
 
 		"1_label_removed_from_1_node_that_has_other_labels_as_well": {
-			labelsToRemove: map[string]string{"a8s.key1": "val1"},
+			keysOfLabelsToRemove: []string{"a8s.key1"},
 			inputNodes: []v1.Node{
 				newNode(
 					withName("n1"),
@@ -972,10 +369,7 @@ func TestUnlabelAllHappyPaths(t *testing.T) {
 		},
 
 		"2_labels_removed_from_1_node_that_has_other_labels_as_well": {
-			labelsToRemove: map[string]string{
-				"a8s.key1": "val1",
-				"a8s.key2": "val2",
-			},
+			keysOfLabelsToRemove: []string{"a8s.key1", "a8s.key2"},
 			inputNodes: []v1.Node{
 				newNode(
 					withName("n1"),
@@ -995,10 +389,7 @@ func TestUnlabelAllHappyPaths(t *testing.T) {
 		},
 
 		"2_labels_removed_from_2_nodes_that_have_no_other_labels": {
-			labelsToRemove: map[string]string{
-				"a8s.key1": "val1",
-				"a8s.key2": "val2",
-			},
+			keysOfLabelsToRemove: []string{"a8s.key1", "a8s.key2"},
 			inputNodes: []v1.Node{
 				newNode(
 					withName("n1"),
@@ -1022,10 +413,7 @@ func TestUnlabelAllHappyPaths(t *testing.T) {
 		},
 
 		"2_labels_removed_from_2_nodes_1_with_other_labels_as_well": {
-			labelsToRemove: map[string]string{
-				"a8s.key1": "val1",
-				"a8s.key2": "val2",
-			},
+			keysOfLabelsToRemove: []string{"a8s.key1", "a8s.key2"},
 			inputNodes: []v1.Node{
 				newNode(
 					withName("n1"),
@@ -1057,10 +445,7 @@ func TestUnlabelAllHappyPaths(t *testing.T) {
 		},
 
 		"1_node_with_labels_but_not_the_ones_to_remove_is_left_unchanged": {
-			labelsToRemove: map[string]string{
-				"a8s.key1": "val1",
-				"a8s.key2": "val2",
-			},
+			keysOfLabelsToRemove: []string{"a8s.key1", "a8s.key2"},
 			inputNodes: []v1.Node{
 				newNode(
 					withName("n1"),
@@ -1082,10 +467,7 @@ func TestUnlabelAllHappyPaths(t *testing.T) {
 		},
 
 		"2_labels_are_removed_from_nodes_that_have_them_but_other_nodes_are_unchanged": {
-			labelsToRemove: map[string]string{
-				"a8s.key1": "val1",
-				"a8s.key2": "val2",
-			},
+			keysOfLabelsToRemove: []string{"a8s.key1", "a8s.key2"},
 			inputNodes: []v1.Node{
 				newNode(
 					withName("n1"),
@@ -1115,10 +497,7 @@ func TestUnlabelAllHappyPaths(t *testing.T) {
 		},
 
 		"only_the_labels_to_remove_that_a_node_has_are_removed": {
-			labelsToRemove: map[string]string{
-				"a8s.key1": "val1",
-				"a8s.key2": "val2",
-			},
+			keysOfLabelsToRemove: []string{"a8s.key1", "a8s.key2"},
 			inputNodes: []v1.Node{
 				newNode(
 					withName("n1"),
@@ -1137,10 +516,7 @@ func TestUnlabelAllHappyPaths(t *testing.T) {
 		},
 
 		"when_removing_2_labels_from_4_nodes_only_the_labels_that_the_nodes_have_are_removed": {
-			labelsToRemove: map[string]string{
-				"a8s.key1": "val1",
-				"a8s.key2": "val2",
-			},
+			keysOfLabelsToRemove: []string{"a8s.key1", "a8s.key2"},
 			inputNodes: []v1.Node{
 				newNode(withName("n1"), withLabels(nil)),
 				newNode(
@@ -1177,10 +553,7 @@ func TestUnlabelAllHappyPaths(t *testing.T) {
 		},
 
 		"2_labels_are_removed_from_a_node_with_master_taints": {
-			labelsToRemove: map[string]string{
-				"a8s.key1": "val1",
-				"a8s.key2": "val2",
-			},
+			keysOfLabelsToRemove: []string{"a8s.key1", "a8s.key2"},
 			inputNodes: []v1.Node{
 				newNode(
 					withName("n1"),
@@ -1205,10 +578,7 @@ func TestUnlabelAllHappyPaths(t *testing.T) {
 		},
 
 		"2_labels_are_removed_from_a_node_with_control_plane_taints": {
-			labelsToRemove: map[string]string{
-				"a8s.key1": "val1",
-				"a8s.key2": "val2",
-			},
+			keysOfLabelsToRemove: []string{"a8s.key1", "a8s.key2"},
 			inputNodes: []v1.Node{
 				newNode(
 					withName("n1"),
@@ -1252,7 +622,7 @@ func TestUnlabelAllHappyPaths(t *testing.T) {
 			}
 
 			// Invoke method under test
-			if err := nodes.UnlabelAll(context.Background(), tc.labelsToRemove); err != nil {
+			if err := nodes.UnlabelAll(context.Background(), tc.keysOfLabelsToRemove); err != nil {
 				t.Fatal("Expected no error when invoking UnlabelAll, got:", err)
 			}
 
@@ -1275,7 +645,7 @@ func TestUnlabelAllHappyPaths(t *testing.T) {
 func TestUnlabelAllListFails(t *testing.T) {
 	t.Parallel()
 
-	labelsToRemove := map[string]string{"a8s.key1": "val1"}
+	keysOfLabelsToRemove := []string{"a8s.key1"}
 	inputNode := newNode(withName("n1"), withLabels(map[string]string{"a8s.key1": "val1"}))
 
 	// Prepare a fake K8s client that is sabotaged to return an error on LIST API calls.
@@ -1292,7 +662,7 @@ func TestUnlabelAllListFails(t *testing.T) {
 	}
 
 	// Invoke the method under test
-	err := nodes.UnlabelAll(context.Background(), labelsToRemove)
+	err := nodes.UnlabelAll(context.Background(), keysOfLabelsToRemove)
 
 	if err == nil {
 		t.Fatal("UnlabelAll returned <nil> error, expected non-nil error")
@@ -1308,15 +678,15 @@ func TestUnlabelAllUpdateFails(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		labelsToRemove map[string]string
-		inputNodes     []v1.Node
-		expectedNodes  []v1.Node
+		keysOfLabelsToRemove []string
+		inputNodes           []v1.Node
+		expectedNodes        []v1.Node
 		// this is a hash map rather than a slice to make it easy to verify if a node's update
 		// should fail with `nodesWhoseUpdateFails[nodeName]`
 		nodesWhoseUpdateFails map[string]struct{}
 	}{
 		"no_node_is_updated_because_updating_fails_for_all_nodes": {
-			labelsToRemove: map[string]string{"a8s.key1": "val1"},
+			keysOfLabelsToRemove: []string{"a8s.key1"},
 			inputNodes: []v1.Node{
 				newNode(withName("n1"), withLabels(map[string]string{"a8s.key1": "val1"})),
 				newNode(withName("n2"), withLabels(map[string]string{"a8s.key1": "val1"})),
@@ -1332,7 +702,7 @@ func TestUnlabelAllUpdateFails(t *testing.T) {
 		},
 
 		"only_1_node_out_of_3_is_updated_because_updating_the_others_fails": {
-			labelsToRemove: map[string]string{"a8s.key1": "val1"},
+			keysOfLabelsToRemove: []string{"a8s.key1"},
 			inputNodes: []v1.Node{
 				newNode(withName("n1"), withLabels(map[string]string{"a8s.key1": "val1"})),
 				newNode(withName("n2"), withLabels(map[string]string{"a8s.key1": "val1"})),
@@ -1382,7 +752,7 @@ func TestUnlabelAllUpdateFails(t *testing.T) {
 			}
 
 			// Invoke method under test
-			err := nodes.UnlabelAll(context.Background(), tc.labelsToRemove)
+			err := nodes.UnlabelAll(context.Background(), tc.keysOfLabelsToRemove)
 
 			if err == nil {
 				t.Fatal("UnlabelAll returned <nil> error, expected non-nil error")
@@ -1420,67 +790,6 @@ func TestUnlabelAllUpdateFails(t *testing.T) {
 					" %#+v\n\n", tc.expectedNodes, gotNodes)
 			}
 		})
-	}
-}
-
-func TestUnlabelAllPanicsWhenLabelKeyMatchesAndValDoesNot(t *testing.T) {
-	t.Parallel()
-
-	// inputNode has a label with the same key but different value as the label to remove, that must
-	// trigger a panic.
-	labelsToRemove := map[string]string{"a8s.key1": "val1"}
-	inputNode := newNode(withName("n1"), withLabels(map[string]string{"a8s.key1": "different-val"}))
-
-	// Set up the object under test.
-	k8sAPINodesClient := fake.
-		NewSimpleClientset(&v1.NodeList{Items: []v1.Node{inputNode}}).
-		CoreV1().
-		Nodes()
-	nodes := node.Client{
-		Nodes:            k8sAPINodesClient,
-		MasterNodeTaints: node.MasterTaintKeys,
-	}
-
-	// Deferred check that the method under test will panic, produce an informative enough message,
-	// and leave the nodes unchanged.
-	defer func() {
-		panicMsg := recover()
-		if panicMsg == nil {
-			t.Fatal("Expected UnlabelAll to panic, but it didn't")
-		}
-		panicMsgStr := fmt.Sprintf("%#+v", panicMsg)
-		if !strings.Contains(panicMsgStr, "a8s.key1") {
-			t.Fatal("Expected UnlabelAll panic message to mention the label key, but it didn't")
-		}
-		if !strings.Contains(panicMsgStr, "val1") {
-			t.Fatal("Expected UnlabelAll panic message to mention the allowed label value, " +
-				"but it didn't")
-		}
-		if !strings.Contains(panicMsgStr, "different-val") {
-			t.Fatal("Expected UnlabelAll panic message to mention the found label value, " +
-				"but it didn't")
-		}
-
-		// To make sure that the node wasn't updated anyway, we get the nodes after invoking the
-		// method under test.
-		gotNodesList, err := k8sAPINodesClient.List(context.Background(), metav1.ListOptions{})
-		if err != nil {
-			t.Fatal("Expected no error when listing nodes, got:", err)
-		}
-		// We only had one node so we can get it at index 0.
-		gotNode := gotNodesList.Items[0]
-
-		// Compare the input node with the got one to ensure it wasn't updated even if there was a
-		// panic.
-		if !equality.Semantic.DeepEqual(inputNode, gotNode) {
-			t.Fatalf("Expected node doesn't match got one\n\n\texpected: %#+v\n\n\tgot:"+
-				" %#+v\n\n", inputNode, gotNode)
-		}
-	}()
-
-	// Invoke the method under test.
-	if err := nodes.UnlabelAll(context.Background(), labelsToRemove); err != nil {
-		t.Fatal("Expected panic when invoking UnlabelAll, got error instead:", err)
 	}
 }
 

--- a/test/integration/topology_awareness/interfaces.go
+++ b/test/integration/topology_awareness/interfaces.go
@@ -23,6 +23,7 @@ type NodesTainter interface {
 }
 
 type NodesLabeler interface {
-	LabelWorkers(context.Context, map[string]string) error
-	UnlabelAll(context.Context, map[string]string) error
+	Label(ctx context.Context, node corev1.Node, labels map[string]string) error
+	UnlabelAll(ctx context.Context, keysOfLabelsToRemove []string) error
+	GetLabels(ctx context.Context, node string) (map[string]string, error)
 }

--- a/test/integration/topology_awareness/object.go
+++ b/test/integration/topology_awareness/object.go
@@ -11,6 +11,7 @@ type Object interface {
 	dsi.StatefulSetGetter
 	dsi.PodsGetter
 	dsi.TolerationsSetter
+	dsi.WithPodAntiAffinity
 }
 
 func newDSI(ds, namespace, name string, replicas int32) (Object, error) {

--- a/test/integration/topology_awareness/topology_awareness_test.go
+++ b/test/integration/topology_awareness/topology_awareness_test.go
@@ -2,12 +2,14 @@ package topology_awareness
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/anynines/a8s-deployment/test/integration/framework"
@@ -23,6 +25,9 @@ import (
 // TODO: Test adding tolerations to an existing DSI.
 // TODO: Test horizontal scale up.
 // TODO: Test cases where only a subset of nodes is tainted.
+// TODO: Test cases where we update affinity and anti-affinity.
+// TODO: Test cases with anti-affinity and upscaling.
+// TODO: Test cases with pod-affinity and upscaling.
 
 const (
 	suffixLength = 5
@@ -32,23 +37,27 @@ const (
 	instancePort = 5432
 
 	taintingTimeout = 15 * time.Second
+	labelingTimeout = 15 * time.Second
 )
 
-var _ = Describe("DSI tolerations to K8s nodes taints", func() {
+var _ = Describe("DSIs topology awareness", func() {
+	var (
+		err error
+		ctx context.Context
+
+		instance       Object
+		instanceNSN    string
+		instanceClient dsi.DSIClient
+
+		sb            *sbv1alpha1.ServiceBinding
+		sbCredentials secret.SecretData
+
+		portForwardStopCh chan struct{}
+		localPort         int
+	)
+
 	Context("DSI has tolerations to node taints", func() {
 		var (
-			err error
-
-			instance       Object
-			instanceNSN    string
-			instanceClient dsi.DSIClient
-
-			sb            *sbv1alpha1.ServiceBinding
-			sbCredentials secret.SecretData
-
-			portForwardStopCh chan struct{}
-			localPort         int
-
 			taints      []corev1.Taint
 			tolerations []corev1.Toleration
 		)
@@ -444,4 +453,328 @@ var _ = Describe("DSI tolerations to K8s nodes taints", func() {
 			})
 		})
 	})
+
+	Context("DSI pods have anti-affinity rules to repel each other", func() {
+		const (
+			a8sTestNodeLabelKey = "a8s-test-host"
+			a8sTestAZLabelKey   = "a8s-test-az"
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+		})
+
+		AfterEach(func() {
+			Eventually(func() error {
+				return nodes.UnlabelAll(ctx, []string{a8sTestNodeLabelKey, a8sTestAZLabelKey})
+			}).Should(Succeed())
+
+			close(portForwardStopCh)
+
+			Expect(k8sClient.Delete(ctx, sb)).To(Succeed(),
+				"failed to delete DSI "+instanceNSN+"'s ServiceBinding")
+
+			Expect(k8sClient.Delete(ctx, instance.GetClientObject())).To(Succeed(),
+				"failed to delete DSI "+instanceNSN)
+		})
+
+		Context("3-replica DSI with each replica in a different AZ", func() {
+			numAZs := 3
+
+			BeforeEach(func() {
+				Eventually(func(g Gomega) {
+					var k8sNodes []corev1.Node
+					k8sNodes, err = nodes.ListWorkers(ctx)
+					g.Expect(err).To(BeNil())
+
+					for i, n := range k8sNodes {
+						az := "az-" + strconv.Itoa(i%numAZs)
+						labelToAdd := map[string]string{a8sTestAZLabelKey: az}
+						g.Expect(nodes.Label(ctx, n, labelToAdd)).To(Succeed())
+					}
+				}).Should(Succeed(), labelingTimeout)
+			})
+
+			It("Implements a 3-replica DSI where each replica is in a different AZ", func() {
+				replicas := int32(3)
+
+				By("Accepting the creation of the DSI API object", func() {
+					// Create the DSI K8s API object
+					instance, err = newDSI(dataservice, testingNamespace,
+						framework.GenerateName(instanceNamePrefix, GinkgoParallelProcess(),
+							suffixLength), replicas)
+					Expect(err).To(BeNil(), "failed to generate DSI object")
+
+					instance.AddRequiredPodAntiAffinityTerm(corev1.PodAffinityTerm{
+						TopologyKey: a8sTestAZLabelKey,
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"a8s.a9s/dsi-name": instance.GetName(),
+								"a8s.a9s/dsi-kind": instance.
+									GetObjectKind().
+									GroupVersionKind().
+									Kind,
+							},
+						},
+					})
+
+					instanceNSN = instance.GetNamespace() + "/" + instance.GetName()
+					Expect(k8sClient.Create(ctx, instance.GetClientObject())).To(Succeed(),
+						"failed to create DSI "+instanceNSN)
+				})
+
+				By("Getting the DSI up and running", func() {
+					dsi.WaitForReadiness(ctx, instance.GetClientObject(), k8sClient)
+				})
+
+				By("Placing the Pods on nodes in different AZs", func() {
+					pods, err := instance.Pods(ctx, k8sClient)
+					Expect(err).To(BeNil())
+					Expect(verifyDSIPodsAreInDifferentAZs(ctx, pods, a8sTestAZLabelKey)).
+						To(Succeed())
+				})
+
+				By("Accepting a ServiceBinding to the DSI", func() {
+					sb = servicebinding.New(
+						servicebinding.SetNamespacedName(instance.GetClientObject()),
+						servicebinding.SetInstanceRef(instance.GetClientObject()),
+					)
+					Expect(k8sClient.Create(ctx, sb)).To(Succeed(),
+						"failed to create ServiceBinding for DSI "+instanceNSN)
+				})
+
+				By("Marking the ServiceBinding as implemented", func() {
+					Eventually(func(g Gomega) {
+						sbNSN := types.NamespacedName{Namespace: sb.Namespace, Name: sb.Name}
+						g.Expect(k8sClient.Get(ctx, sbNSN, sb)).
+							To(Succeed(), "failed to get DSI "+instanceNSN+"'s ServiceBinding")
+						g.Expect(sb.Status.Implemented).
+							To(BeTrue(), "ServiceBinding of DSI "+instanceNSN+" isn't implemented")
+					}, 10*time.Second).Should(Succeed(),
+						"failed to verify that the ServiceBinding of DSI "+instanceNSN+
+							" gets implemented")
+				})
+
+				By("Generating a client to the DSI to read/write to/from it", func() {
+					// Get credentials to write to the DSI
+					sbCredentials, err = secret.Data(
+						ctx, k8sClient, servicebinding.SecretName(sb.Name), testingNamespace)
+					Expect(err).To(BeNil(), "failed to parse secret data for ServiceBinding "+
+						sb.GetNamespace()+"/"+sb.GetName())
+
+					// Create a portforwarding to write to the DSI from out of cluster
+					portForwardStopCh, localPort, err = framework.PortForward(
+						ctx, instancePort, kubeconfigPath, instance, k8sClient)
+					Expect(err).To(BeNil(), "failed to establish portforward to DSI "+instanceNSN)
+
+					// Generate a client to the DSI using the credentials and the portforwarding
+					instanceClient, err = dsi.NewClient(dataservice,
+						strconv.Itoa(localPort),
+						sbCredentials)
+					Expect(err).To(BeNil(), "failed to create client to DSI "+instanceNSN)
+				})
+
+				By("Setting up the DSI so that clients can write/read data into/from it", func() {
+					Expect(instanceClient.Write(ctx, appsDefaultDB, "sample data")).To(Succeed(),
+						"failed to write into database "+appsDefaultDB+" in DSI "+instanceNSN)
+					readData, err := instanceClient.Read(ctx, appsDefaultDB)
+					Expect(err).To(BeNil(),
+						"failed to read data from database "+appsDefaultDB+" in DSI "+instanceNSN)
+					Expect(readData).To(Equal("sample data"),
+						"data read from database "+appsDefaultDB+" in DSI "+instanceNSN+
+							" doesn't match previously written data")
+				})
+			})
+		})
+
+		Context("3-replica DSI in a cluster with 3 hosts but only 2 AZs", func() {
+			numAZs := 2
+			numNodes := 3
+
+			BeforeEach(func() {
+				Eventually(func(g Gomega) {
+					var k8sNodes []corev1.Node
+					k8sNodes, err = nodes.ListWorkers(ctx)
+					g.Expect(err).To(BeNil())
+
+					for i, n := range k8sNodes {
+						az := "az-" + strconv.Itoa(i%numAZs)
+						node := "node-" + strconv.Itoa(i%numNodes)
+						labelsToAdd := map[string]string{
+							a8sTestAZLabelKey:   az,
+							a8sTestNodeLabelKey: node,
+						}
+						g.Expect(nodes.Label(ctx, n, labelsToAdd)).To(Succeed())
+					}
+				}).Should(Succeed(), labelingTimeout)
+			})
+
+			It("Implements a 3-replica DSI with replicas spread across 3 hosts and 2 AZs", func() {
+				replicas := int32(3)
+
+				By("Accepting the creation of the DSI API object", func() {
+					// Create the DSI K8s API object
+					instance, err = newDSI(dataservice, testingNamespace,
+						framework.GenerateName(instanceNamePrefix, GinkgoParallelProcess(),
+							suffixLength), replicas)
+					Expect(err).To(BeNil(), "failed to generate DSI object")
+
+					instance.AddRequiredPodAntiAffinityTerm(corev1.PodAffinityTerm{
+						TopologyKey: a8sTestNodeLabelKey,
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"a8s.a9s/dsi-name": instance.GetName(),
+								"a8s.a9s/dsi-kind": instance.
+									GetObjectKind().
+									GroupVersionKind().
+									Kind,
+							},
+						},
+					})
+
+					instance.AddPreferredPodAntiAffinityTerm(100, corev1.PodAffinityTerm{
+						TopologyKey: a8sTestAZLabelKey,
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"a8s.a9s/dsi-name": instance.GetName(),
+								"a8s.a9s/dsi-kind": instance.
+									GetObjectKind().
+									GroupVersionKind().
+									Kind,
+							},
+						},
+					})
+
+					instanceNSN = instance.GetNamespace() + "/" + instance.GetName()
+					Expect(k8sClient.Create(ctx, instance.GetClientObject())).To(Succeed(),
+						"failed to create DSI "+instanceNSN)
+				})
+
+				By("Getting the DSI up and running", func() {
+					dsi.WaitForReadiness(ctx, instance.GetClientObject(), k8sClient)
+				})
+
+				By("Placing the Pods on different nodes and not in just one AZ", func() {
+					pods, err := instance.Pods(ctx, k8sClient)
+					Expect(err).To(BeNil())
+					Expect(verifyDSIPodsAreOnDifferentNodes(ctx, pods, a8sTestNodeLabelKey)).
+						To(Succeed())
+					Expect(verifyDSIPodsAreInMoreThanOneAZ(ctx, pods, a8sTestAZLabelKey)).
+						To(Succeed())
+				})
+
+				By("Accepting a ServiceBinding to the DSI", func() {
+					sb = servicebinding.New(
+						servicebinding.SetNamespacedName(instance.GetClientObject()),
+						servicebinding.SetInstanceRef(instance.GetClientObject()),
+					)
+					Expect(k8sClient.Create(ctx, sb)).To(Succeed(),
+						"failed to create ServiceBinding for DSI "+instanceNSN)
+				})
+
+				By("Marking the ServiceBinding as implemented", func() {
+					Eventually(func(g Gomega) {
+						sbNSN := types.NamespacedName{Namespace: sb.Namespace, Name: sb.Name}
+						g.Expect(k8sClient.Get(ctx, sbNSN, sb)).
+							To(Succeed(), "failed to get DSI "+instanceNSN+"'s ServiceBinding")
+						g.Expect(sb.Status.Implemented).
+							To(BeTrue(), "ServiceBinding of DSI "+instanceNSN+" isn't implemented")
+					}, 10*time.Second).Should(Succeed(),
+						"failed to verify that the ServiceBinding of DSI "+instanceNSN+
+							" gets implemented")
+				})
+
+				By("Generating a client to the DSI to read/write to/from it", func() {
+					// Get credentials to write to the DSI
+					sbCredentials, err = secret.Data(
+						ctx, k8sClient, servicebinding.SecretName(sb.Name), testingNamespace)
+					Expect(err).To(BeNil(), "failed to parse secret data for ServiceBinding "+
+						sb.GetNamespace()+"/"+sb.GetName())
+
+					// Create a portforwarding to write to the DSI from out of cluster
+					portForwardStopCh, localPort, err = framework.PortForward(
+						ctx, instancePort, kubeconfigPath, instance, k8sClient)
+					Expect(err).To(BeNil(), "failed to establish portforward to DSI "+instanceNSN)
+
+					// Generate a client to the DSI using the credentials and the portforwarding
+					instanceClient, err = dsi.NewClient(dataservice,
+						strconv.Itoa(localPort),
+						sbCredentials)
+					Expect(err).To(BeNil(), "failed to create client to DSI "+instanceNSN)
+				})
+
+				By("Setting up the DSI so that clients can write/read data into/from it", func() {
+					Expect(instanceClient.Write(ctx, appsDefaultDB, "sample data")).To(Succeed(),
+						"failed to write into database "+appsDefaultDB+" in DSI "+instanceNSN)
+					readData, err := instanceClient.Read(ctx, appsDefaultDB)
+					Expect(err).To(BeNil(),
+						"failed to read data from database "+appsDefaultDB+" in DSI "+instanceNSN)
+					Expect(readData).To(Equal("sample data"),
+						"data read from database "+appsDefaultDB+" in DSI "+instanceNSN+
+							" doesn't match previously written data")
+				})
+			})
+		})
+	})
+
 })
+
+func verifyDSIPodsAreInDifferentAZs(ctx context.Context,
+	dsiPods []corev1.Pod,
+	azLabelKey string) error {
+
+	return verifyDSIPodsAreInDifferentTopologyDomains(ctx, dsiPods, "AZ", azLabelKey)
+}
+
+func verifyDSIPodsAreOnDifferentNodes(ctx context.Context,
+	dsiPods []corev1.Pod,
+	nodeLabelKey string) error {
+
+	return verifyDSIPodsAreInDifferentTopologyDomains(ctx, dsiPods, "node", nodeLabelKey)
+}
+
+func verifyDSIPodsAreInDifferentTopologyDomains(ctx context.Context,
+	dsiPods []corev1.Pod,
+	topologyDomainName, topologyDomainKey string) error {
+
+	domainToPod := map[string]string{}
+	for _, p := range dsiPods {
+		podNodeLabels, err := nodes.GetLabels(ctx, p.Spec.NodeName)
+		if err != nil {
+			return fmt.Errorf("failed to verify that all dsi pods are in different %ss: %w",
+				topologyDomainName, err)
+		}
+
+		podDomain := podNodeLabels[topologyDomainKey]
+		if otherPodInDomain := domainToPod[podDomain]; otherPodInDomain != "" {
+			return fmt.Errorf("all dsi pods should be in different %ss but pods %s and %s are "+
+				"both in %s %s", topologyDomainName, p.Name, otherPodInDomain, topologyDomainName,
+				podDomain)
+		}
+		domainToPod[podDomain] = p.Name
+	}
+
+	return nil
+}
+
+func verifyDSIPodsAreInMoreThanOneAZ(ctx context.Context,
+	dsiPods []corev1.Pod,
+	azLabelKey string) error {
+
+	seenAZs := map[string]struct{}{}
+	podAZ := ""
+	for _, p := range dsiPods {
+		podNodeLabels, err := nodes.GetLabels(ctx, p.Spec.NodeName)
+		if err != nil {
+			return fmt.Errorf("failed to verify that dsi pods are in more than one AZ: %w", err)
+		}
+
+		podAZ = podNodeLabels[azLabelKey]
+		seenAZs[podAZ] = struct{}{}
+		if len(seenAZs) > 1 {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("all dsi pods are in AZ %s when they should be in more than one AZ", podAZ)
+}


### PR DESCRIPTION
Add functions to list all the K8s cluster nodes and all the worker nodes (i.e. leave out master nodes) to the testing framework.

Add unit tests for said functions.

Refactor the nodes client to use the newly added functions.

Add godoc comments on all the exported function.

# Checks

- [x] Commit message adheres to our [guideline](https://anynines.atlassian.net/wiki/spaces/DS/pages/2423193626/Version+Control+Workflow)
