### PR TITLE
Use logr with zap implementation for node client

### DIFF
--- a/test/go.mod
+++ b/test/go.mod
@@ -6,9 +6,12 @@ require (
 	github.com/anynines/a8s-backup-manager v0.17.0
 	github.com/anynines/a8s-service-binding-controller v0.19.0
 	github.com/anynines/postgresql-operator v0.34.0
+	github.com/go-logr/logr v1.2.2
+	github.com/go-logr/zapr v1.2.3
 	github.com/jackc/pgx/v4 v4.14.1
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
+	go.uber.org/zap v1.20.0
 	k8s.io/api v0.23.3
 	k8s.io/apimachinery v0.23.3
 	k8s.io/cli-runtime v0.23.1
@@ -26,7 +29,6 @@ require (
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
-	github.com/go-logr/logr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.14 // indirect
@@ -72,6 +74,8 @@ require (
 	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
+	go.uber.org/atomic v1.9.0 // indirect
+	go.uber.org/multierr v1.7.0 // indirect
 	golang.org/x/crypto v0.0.0-20220128200615-198e4374d7ed // indirect
 	golang.org/x/net v0.0.0-20220412020605-290c469a71a5 // indirect
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -91,6 +91,7 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
+github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -187,8 +188,9 @@ github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbV
 github.com/go-logr/logr v1.2.2 h1:ahHml/yUpnlb96Rp8HCvtYVPY8ZYpxq3g7UYchIYwbs=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/zapr v1.2.0/go.mod h1:Qa4Bsj2Vb+FAVeAKsLD8RLQ+YRJB8YDmOAKxaBQf7Ro=
-github.com/go-logr/zapr v1.2.2 h1:5YNlIL6oZLydaV4dOFjL8YpgXF/tPeTbnpatnu3cq6o=
 github.com/go-logr/zapr v1.2.2/go.mod h1:eIauM6P8qSvTw5o2ez6UEAfGjQKrxQTl5EoK+Qa2oG4=
+github.com/go-logr/zapr v1.2.3 h1:a9vnzlIBPQBBkeaR9IuMUfmVOrQlkoC4YfPoFkX3T7A=
+github.com/go-logr/zapr v1.2.3/go.mod h1:eIauM6P8qSvTw5o2ez6UEAfGjQKrxQTl5EoK+Qa2oG4=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUeOFYEICuY=
 github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=

--- a/test/integration/framework/log/log.go
+++ b/test/integration/framework/log/log.go
@@ -1,0 +1,21 @@
+package log
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+)
+
+func NewWithNames(names ...string) logr.Logger {
+	zapLogger, err := zap.NewDevelopment()
+	if err != nil {
+		panic(err)
+	}
+
+	logger := zapr.NewLogger(zapLogger)
+	for _, n := range names {
+		logger = logger.WithName(n)
+	}
+
+	return logger
+}

--- a/test/integration/framework/node/client_test.go
+++ b/test/integration/framework/node/client_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -83,6 +84,7 @@ func TestListAllHappyPaths(t *testing.T) {
 			nodes := node.Client{
 				Nodes:            k8sAPINodesClient,
 				MasterNodeTaints: node.MasterTaintKeys,
+				Log:              logr.Discard(),
 			}
 
 			// Invoke the method under test.
@@ -120,6 +122,7 @@ func TestListAllFails(t *testing.T) {
 	nodes := node.Client{
 		Nodes:            k8sClient.CoreV1().Nodes(),
 		MasterNodeTaints: node.MasterTaintKeys,
+		Log:              logr.Discard(),
 	}
 
 	// Invoke the method under test
@@ -243,6 +246,7 @@ func TestListWorkersHappyPaths(t *testing.T) {
 			nodes := node.Client{
 				Nodes:            k8sAPINodesClient,
 				MasterNodeTaints: node.MasterTaintKeys,
+				Log:              logr.Discard(),
 			}
 
 			// Invoke the method under test.
@@ -280,6 +284,7 @@ func TestListWorkersFails(t *testing.T) {
 	nodes := node.Client{
 		Nodes:            k8sClient.CoreV1().Nodes(),
 		MasterNodeTaints: node.MasterTaintKeys,
+		Log:              logr.Discard(),
 	}
 
 	// Invoke the method under test
@@ -619,6 +624,7 @@ func TestUnlabelAllHappyPaths(t *testing.T) {
 			nodes := node.Client{
 				Nodes:            k8sAPINodesClient,
 				MasterNodeTaints: node.MasterTaintKeys,
+				Log:              logr.Discard(),
 			}
 
 			// Invoke method under test
@@ -659,6 +665,7 @@ func TestUnlabelAllListFails(t *testing.T) {
 	nodes := node.Client{
 		Nodes:            sabotagedK8sClient.CoreV1().Nodes(),
 		MasterNodeTaints: node.MasterTaintKeys,
+		Log:              logr.Discard(),
 	}
 
 	// Invoke the method under test
@@ -749,6 +756,7 @@ func TestUnlabelAllUpdateFails(t *testing.T) {
 			nodes := node.Client{
 				Nodes:            k8sAPINodesClient,
 				MasterNodeTaints: node.MasterTaintKeys,
+				Log:              logr.Discard(),
 			}
 
 			// Invoke method under test
@@ -1208,6 +1216,7 @@ func TestTaintWorkersHappyPaths(t *testing.T) {
 			nodes := node.Client{
 				Nodes:            k8sAPINodesClient,
 				MasterNodeTaints: node.MasterTaintKeys,
+				Log:              logr.Discard(),
 			}
 
 			// Invoke method under test
@@ -1569,6 +1578,7 @@ func TestUntaintAllHappyPaths(t *testing.T) {
 			nodes := node.Client{
 				Nodes:            k8sAPINodesClient,
 				MasterNodeTaints: node.MasterTaintKeys,
+				Log:              logr.Discard(),
 			}
 
 			// Invoke method under test


### PR DESCRIPTION
# Short Description
Use logr with zap implementation for node client. Logr with zap implementation is consistent with how logging is done with our controllers.

# Checks
- [x] Commit message adheres to our [guideline](https://anynines.atlassian.net/wiki/spaces/DS/pages/2423193626/Version+Control+Workflow)
