### PR TITLE
Add separate ServiceAccount for Postgresql Operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - backup-manager now uses a dedicated ServiceAccount, instead of the default one
 - service-binding controller now uses a dedicated ServiceAccount, instead of the default one
+- postgresql-operator now used a dedicated ServiceAccount, instead of the default one
 
 ## [0.1.0] - 2022-06-27
 

--- a/deploy/a8s/manifests/postgresql-operator.yaml
+++ b/deploy/a8s/manifests/postgresql-operator.yaml
@@ -1294,6 +1294,12 @@ status:
   conditions: []
   storedVersions: []
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: postgresql-manager-account
+  namespace: a8s-system
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -1474,7 +1480,7 @@ roleRef:
   name: postgresql-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: postgresql-manager-account
   namespace: a8s-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1487,7 +1493,7 @@ roleRef:
   name: postgresql-manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: postgresql-manager-account
   namespace: a8s-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1632,6 +1638,7 @@ spec:
           name: image-config
       securityContext:
         runAsUser: 65532
+      serviceAccountName: postgresql-manager-account
       terminationGracePeriodSeconds: 10
       volumes:
       - name: cert


### PR DESCRIPTION
# Short Description
Change ServiceAccount for pg operator to a dedicated one instead of "default"
# Details

# Checks
- [ ] Documentation has been adjusted
- [ ] Architectural decisions have been documented
- [x] Changelog has been updated
- [x] Manifests are updated
- [x] Commit message adheres to our [guideline](https://anynines.atlassian.net/wiki/spaces/DS/pages/2423193626/Version+Control+Workflow)
