### PR TITLE
Extend postgresql conversion webhooks tests

### DIFF
--- a/docs/application-developers/advanced_configuration.md
+++ b/docs/application-developers/advanced_configuration.md
@@ -20,7 +20,7 @@ resource and/or make PostgreSQL instances more resilient against failures by
 setting up highly available instances. In general, these settings are exposed
 through the `spec.schedulingConstraints` field for example in the `Postgresql`
 objects (see [API
-Documentation](/docs/application-developers/api-documentation/api_reference.md#postgresqlschedulingconstraints)). 
+Documentation](/docs/application-developers/api-documentation/postgresql-operator/v1beta3.md#postgresqlschedulingconstraints)).
 
 Subfields of `schedulingConstraints` allow you to configure
 [tolerations][taints-and-tolerations], [node

--- a/docs/application-developers/usage_overview.md
+++ b/docs/application-developers/usage_overview.md
@@ -204,33 +204,33 @@ If you want to restore a data service instance to a previous state it had, you c
 a previously taken backup (as shown in section
 [Take a Backup of the PostgreSQL Instance](#take-a-backup-of-the-postgresql-instance)).
 
-To do that, you have to create a custom API object of kind `Recovery` (a custom kind which is part
-of a8s). A `Recovery` API object fields identify the `Backup` API object to use to perform the
-restore. The `Recovery` will always be performed on the data service instance from which the backup
-was taken. Stay tuned for a complete reference of all the fields of `Recovery` API objects.
+To do that, you have to create a custom API object of kind `Restore` (a custom kind which is part
+of a8s). A `Restore` API object fields identify the `Backup` API object to use to perform the
+restore. The `Restore` will always be performed on the data service instance from which the backup
+was taken. Stay tuned for a complete reference of all the fields of `Restore` API objects.
 
 At [examples/restore.yaml](/examples/restore.yaml) there's the yaml manifest of an example
-`Recovery` that points to the PostgreSQL instance that you previously deployed. Run:
+`Restore` that points to the PostgreSQL instance that you previously deployed. Run:
 
 ```shell
 kubectl apply --filename examples/restore.yaml
 ```
 
 The a8s control plane will react by downloading the relevant backup and using it to restore the data
-service instance. This might take some time, to learn when the recovery has completed, run:
+service instance. This might take some time, to learn when the restore has completed, run:
 
 ```shell
-kubectl wait recovery recovery-sample --for=condition=complete
+kubectl wait restore recovery-sample --for=condition=complete
 ```
 
-and wait until the command has finished. If your recovery takes a long time to complete, you may
+and wait until the command has finished. If your restore takes a long time to complete, you may
 need to run the `kubectl wait` command multiple times or adjust the timeout using the
  `--timeout=<n>s` flag.
 
-When you want to delete a `Recovery`, run:
+When you want to delete a `Restore`, run:
 
 ```shell
-kubectl delete recovery <recovery-name>
+kubectl delete restore <restore-name>
 ```
 
 ## Visualize the Logs of the PostgreSQL Instance

--- a/docs/platform-operators/installing_framework.md
+++ b/docs/platform-operators/installing_framework.md
@@ -137,10 +137,9 @@ order.
 
 More precisely, it will:
 
-1. Create two namespaces called `a8s-system` and `postgresql-system`.
-   The `postgresql-system` namespace is used for the `postgresql-controller-manager`, the rest of
-   the a8s framework components (`a8s-backup-controller-manager` and
-   `service-binding-controller-manager`) are running in `a8s-system`.
+1. Create a namespace called `a8s-system`.
+   The a8s framework components `postgresql-controller-manager`, `a8s-backup-controller-manager` and
+   `service-binding-controller-manager` will be running in `a8s-system` namespace.
 2. Register multiple CustomResourceDefinitions (CRDs)
 3. Create three deployments, one for each a8s framework component
 4. Create multiple ClusterRoles and ClusterRoleBindings:
@@ -171,22 +170,15 @@ are ready (value `1/1` under the `READY` column):
 
 ```shell
 watch kubectl get deployment --namespace a8s-system
-watch kubectl get deployment --namespace postgresql-system
 ```
 
-the output of the first command should be similar to:
+the output of the command should be similar to:
 
 ```shell
 NAME                                 READY   UP-TO-DATE   AVAILABLE   AGE
 a8s-backup-controller-manager        1/1     1            1           105s
 service-binding-controller-manager   1/1     1            1           105s
-```
-
-the output of the second command should be similar to:
-
-```shell
-NAME                            READY   UP-TO-DATE   AVAILABLE   AGE
-postgresql-controller-manager   1/1     1            1           25m
+postgresql-controller-manager        1/1     1            1           105s
 ```
 
 ### Using the OLM


### PR DESCRIPTION
# Short Description
Added and extended existing tests to cover more scenarios like create, update and delete for conversion webhook. Conversion tests for v1beta3 to v1alpha1 were also added. 
# Details
Conversion webhook tests for Postgresql operator now test update and delete workflows. Similarly create tests were also extended.
Also fixed a few typos I found during my onboarding in docs.
# Checks
- [x] Documentation has been adjusted
- [ ] Architectural decisions have been documented
- [ ] Changelog has been updated
- [ ] Manifests are updated
- [x] Commit message adheres to our [guideline](https://anynines.atlassian.net/wiki/spaces/DS/pages/2423193626/Version+Control+Workflow)
