### PR TITLE
Remove redundant unit test

### DIFF
--- a/deploy/a8s/manifests/postgresql-operator.yaml
+++ b/deploy/a8s/manifests/postgresql-operator.yaml
@@ -2962,7 +2962,7 @@ spec:
         - --leader-elect
         command:
         - postgresql-operator
-        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/postgresql-operator:fa4c1a4aeff8f3a632352958664f8d1f1a746044
+        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/postgresql-operator:b1ab3622bc6eb71071a91c4c0953c9249c5585fe
         livenessProbe:
           httpGet:
             path: /healthz

--- a/test/go.mod
+++ b/test/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/anynines/a8s-backup-manager v0.34.0
 	github.com/anynines/a8s-service-binding-controller v0.34.1-0.20230125140308-36f252e2ccf3
-	github.com/anynines/postgresql-operator v0.83.1-0.20230313225625-fa4c1a4aeff8
+	github.com/anynines/postgresql-operator v0.85.1-0.20230320104034-b1ab3622bc6e
 	github.com/chaos-mesh/chaos-mesh/api v0.0.0-20230209235359-64dc83baed9b
 	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.3

--- a/test/go.sum
+++ b/test/go.sum
@@ -10,8 +10,8 @@ github.com/anynines/a8s-backup-manager v0.34.0 h1:VBfA7kVjkzo26+zrYC3t4dTtTPkiXD
 github.com/anynines/a8s-backup-manager v0.34.0/go.mod h1:yayIzv5u31WcEGsa+vQExuPjAxZzdirZ5gIrqoxftIA=
 github.com/anynines/a8s-service-binding-controller v0.34.1-0.20230125140308-36f252e2ccf3 h1:StZXWE3ROEJ2eb746fwWueBYyK4FxTIpMWZRvunDyDU=
 github.com/anynines/a8s-service-binding-controller v0.34.1-0.20230125140308-36f252e2ccf3/go.mod h1:ghpRFX+mrllDZ3TP3zhVZ2WYDfONaOhv1Uk7szK/Uqs=
-github.com/anynines/postgresql-operator v0.83.1-0.20230313225625-fa4c1a4aeff8 h1:pzVrJvjAsYIRLwV3nnTJtYZ3ZP6LFEeIP+HymlGRGSg=
-github.com/anynines/postgresql-operator v0.83.1-0.20230313225625-fa4c1a4aeff8/go.mod h1:aV/94/fffpTy2lY1AqbtJP0Z0DzWRTmMF0SrCj84noY=
+github.com/anynines/postgresql-operator v0.85.1-0.20230320104034-b1ab3622bc6e h1:j/jRXjKI/QRms7lqn03WiBE5DsRqSJws9C163kCZO5w=
+github.com/anynines/postgresql-operator v0.85.1-0.20230320104034-b1ab3622bc6e/go.mod h1:aV/94/fffpTy2lY1AqbtJP0Z0DzWRTmMF0SrCj84noY=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=


### PR DESCRIPTION
Bump postgresql-operator version. The change isn't user-visible, it only affects the pg operator's unit tests.