### PR TITLE
Mention external load balancers prerequisite

### DIFF
--- a/docs/technical_requirements.md
+++ b/docs/technical_requirements.md
@@ -10,6 +10,11 @@ To try out a8s you will need:
 - one [StorageClass][storage-class] marked as `default` in the Kubernetes cluster
 - one AWS S3 bucket for storing Backups
 
+If you want your data service instances to have IPs reachable from outside the K8s cluster
+(by using the feature described
+[here](./application-developers/advanced_configuration.md#usage-outside-the-kubernetes-cluster)),
+the K8s cluster must support [external load balancers][k8s-load-balancer-services].
+
 To access the included Dashboards (Grafana, OpenSearch Dashboards) it is also
 recommended to deploy an Ingress Controller on your cluster. To access the
 Dashboards you can then expose the Dashboard Services, for more information on
@@ -55,3 +60,4 @@ marginally.
 
 [storage-class]: https://kubernetes.io/docs/concepts/storage/storage-classes/
 [k8s-ingress]: https://kubernetes.io/docs/concepts/services-networking/ingress/
+[k8s-load-balancer-services]: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer


### PR DESCRIPTION
Mention that some features require the K8s cluster to support external load balancers in the technical requirements doc.

Before this PR this requirement is written only in less discoverable places.

# Checks
- [x] Documentation has been adjusted
- [x] Commit message adheres to our [guideline](https://anynines.atlassian.net/wiki/spaces/DS/pages/2423193626/Version+Control+Workflow)
