### PR TITLE
Remove stale limitations from limitations docs

### DIFF
--- a/docs/current_limitations.md
+++ b/docs/current_limitations.md
@@ -36,7 +36,6 @@
   and use it to write/read data to/from the instance, etc...).
 - Given an instance, there's no multi-tenancy: all service bindings to
   it will share the same database.
-- Instances cannot be used from outside the cluster.
 
 ## Backup and Restore
 


### PR DESCRIPTION
Remove statement about lack of support for out-of-cluster access to DSIs from the doc listing the current a8s limitations, because we added support for out-of-cluster access.

# Checks
- [x] Documentation has been adjusted
- [x] Commit message adheres to our [guideline](https://anynines.atlassian.net/wiki/spaces/DS/pages/2423193626/Version+Control+Workflow)
