### PR TITLE
Enable running controller locally

### DIFF
--- a/deploy/a8s/manifests/postgresql-operator.yaml
+++ b/deploy/a8s/manifests/postgresql-operator.yaml
@@ -1673,7 +1673,7 @@ spec:
         - --leader-elect
         command:
         - postgresql-operator
-        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/postgresql-operator:c01af5af858b4a5186460a51d5a1f34a5d428317
+        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/postgresql-operator:0fc73bad4ebc931348fcde47cc9a245615124760
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1808,3 +1808,4 @@ webhooks:
     resources:
     - postgresqls
   sideEffects: None
+


### PR DESCRIPTION
Bump postgresql-operator version, generate new manifests for
deploying postgresql-operator and update API documentation to
integrate PR Enable running controller locally
