### PR TITLE
Add Labels to filter Kind incompatible tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -36,10 +36,18 @@ test cases test the same coarse-grained functionality.
   end-to-end tests, run `go test ./e2e/backup` from inside the test directory.
 - `go test` can also be replaced by `ginkgo` for more informative output.
 
+Some tests are not compatible with certain environments. They are labeled accordingly
+so they can be skipped using the GinkGo CLI. For example the following command will
+skip tests that don't work in Kind.
+
+``` sh
+ginkgo run --label-filter='!KindIncompatible' ./...
+```
+
 If your run includes the `chaos-tests`, you will have to install
 [ChaosMesh](https://chaos-mesh.org/). As the installation is specific to the
 container runtime used in your cluster, refer to the [official installation
-guide](https://chaos-mesh.org/docs/production-installation-using-helm/). 
+guide](https://chaos-mesh.org/docs/production-installation-using-helm/).
 
 ### Adding or Modifying Tests
 

--- a/test/e2e/postgresql/exposed_cluster_test.go
+++ b/test/e2e/postgresql/exposed_cluster_test.go
@@ -21,7 +21,7 @@ const (
 	SSLModeRequired = "require"
 )
 
-var _ = Describe("end-to-end tests for exposed instances", func() {
+var _ = Describe("end-to-end tests for exposed instances", Label("ExternalLoadbalancer", "KindIncompatible"), func() {
 
 	Context("Instance exposed via Load Balancer", Ordered, func() {
 		AfterAll(func() {


### PR DESCRIPTION
# Short Description
Add a label to filter kind incompatible tests by

# Details
I added two labels `ExternalLoadbalancer` and `KindIncompatible`. I assume that we might have different tests that may not be runnable in kind. The `ExternalLoadbalancer` label was also added, in case we have other testing environments that don't support it in the future.

# Note

WARNING: Only users listed in the CODEOWNERS file can approve PRs!

# Checks

- [x] Documentation has been adjusted
- [ ] PR is approved by a code owner
- [ ] Commit message adheres to our [guideline](https://anynines.atlassian.net/wiki/spaces/DS/pages/2423193626/Version+Control+Workflow)
