### PR TITLE
Explicitly set the default namespace

### DIFF
--- a/examples/backup.yaml
+++ b/examples/backup.yaml
@@ -2,6 +2,7 @@ apiVersion: backups.anynines.com/v1beta3
 kind: Backup
 metadata:
   name: backup-sample
+  namespace: default
 spec:
   serviceInstance:
     apiGroup: "postgresql.anynines.com"

--- a/examples/postgresql-instance.yaml
+++ b/examples/postgresql-instance.yaml
@@ -2,6 +2,7 @@ apiVersion: postgresql.anynines.com/v1beta3
 kind: Postgresql
 metadata:
   name: sample-pg-cluster
+  namespace: default
 spec:
   replicas: 3
   volumeSize: 1Gi

--- a/examples/restore.yaml
+++ b/examples/restore.yaml
@@ -2,6 +2,7 @@ apiVersion: backups.anynines.com/v1beta3
 kind: Restore
 metadata:
   name: recovery-sample
+  namespace: default
 spec:
   serviceInstance:
     apiGroup: "postgresql.anynines.com"

--- a/examples/service-binding.yaml
+++ b/examples/service-binding.yaml
@@ -2,6 +2,7 @@ apiVersion: servicebindings.anynines.com/v1beta3
 kind: ServiceBinding
 metadata:
   name: sb-sample
+  namespace: default
 spec:
   instance:
     apiVersion: postgresql.anynines.com/v1beta3


### PR DESCRIPTION
# Short Description

Updated the example docs to explicitly have the default namespace set

# Details

If the namespace context is set locally, the example files fail to apply because some resources are deployed in the default space, but other resources look for them in the context namespace. Setting the namespace explicitly will address this issue.

# Note

WARNING: Only users listed in the CODEOWNERS file can approve PRs!

# Checks

- [ ] ~~Documentation has been adjusted~~
- [ ] ~~Architectural decisions have been documented~~
- [ ] ~~Changelog has been updated~~
- [ ] PR is approved by a code owner
- [ ] ~~Manifests are updated~~
- [x] Commit message adheres to our [guideline](https://anynines.atlassian.net/wiki/spaces/DS/pages/2423193626/Version+Control+Workflow)
