### PR TITLE
Add dockerfile and update Image of backup-agent

### DIFF
--- a/deploy/a8s/manifests/postgresql-images.yaml
+++ b/deploy/a8s/manifests/postgresql-images.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  backupAgentImage: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/backup-agent:781ca7b6e9bb4af66aeedb5046b50dc1c2b6c638
+  backupAgentImage: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/backup-agent:81450cbb7f94fa020441361d8c64ew89499acd13
   extensionCleanupImage: alpine:3.16.0
   extensionImageRegistry: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/postgresql-operator/postgresql-extensions
   spiloImage: ghcr.io/zalando/spilo-15:3.0-p1

--- a/deploy/a8s/manifests/postgresql-operator.yaml
+++ b/deploy/a8s/manifests/postgresql-operator.yaml
@@ -1673,7 +1673,7 @@ spec:
         - --leader-elect
         command:
         - postgresql-operator
-        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/postgresql-operator:37d4a2e9d311ff66d8fc5b1d570d08232720754d
+        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/postgresql-operator:3103614f958d687f61cbf924a7c9faea3ad7ee72
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Bump postgresql-operator version, generate new manifests for
deploying postgresql-operator and update API documentation to
integrate PR Add dockerfile and update Image of backup-agent
