### PR TITLE
Increase memory limit to prevent PostGIS OOMKilled

### DIFF
--- a/docs/application-developers/advanced_configuration.md
+++ b/docs/application-developers/advanced_configuration.md
@@ -122,7 +122,7 @@ spec:
     requests:
       cpu: 100m
     limits:
-      memory: 100Mi
+      memory: 200Mi
   schedulingConstraints:
     affinity:
       podAntiAffinity:
@@ -248,7 +248,7 @@ spec:
     requests:
       cpu: 100m
     limits:
-      memory: 100Mi
+      memory: 200Mi
   schedulingConstraints:
     affinity:
       podAntiAffinity:
@@ -389,7 +389,7 @@ spec:
     requests:
       cpu: 100m
     limits:
-      memory: 100Mi
+      memory: 200Mi
   schedulingConstraints:
     affinity:
       nodeAffinity:

--- a/examples/postgresql-ha-1-instance.yaml
+++ b/examples/postgresql-ha-1-instance.yaml
@@ -9,7 +9,7 @@ spec:
     requests:
       cpu: 100m
     limits:
-      memory: 100Mi
+      memory: 200Mi
   schedulingConstraints:
     affinity:
       podAntiAffinity:

--- a/examples/postgresql-ha-2-instance.yaml
+++ b/examples/postgresql-ha-2-instance.yaml
@@ -9,7 +9,7 @@ spec:
     requests:
       cpu: 100m
     limits:
-      memory: 100Mi
+      memory: 200Mi
   schedulingConstraints:
     affinity:
       podAntiAffinity:

--- a/examples/postgresql-instance-exposed.yaml
+++ b/examples/postgresql-instance-exposed.yaml
@@ -11,4 +11,4 @@ spec:
     requests:
       cpu: 100m
     limits:
-      memory: 100Mi
+      memory: 200Mi

--- a/examples/postgresql-instance.yaml
+++ b/examples/postgresql-instance.yaml
@@ -10,4 +10,4 @@ spec:
     requests:
       cpu: 100m
     limits:
-      memory: 100Mi
+      memory: 200Mi

--- a/examples/postgresql-toleration-instance.yaml
+++ b/examples/postgresql-toleration-instance.yaml
@@ -9,7 +9,7 @@ spec:
     requests:
       cpu: 100m
     limits:
-      memory: 100Mi
+      memory: 200Mi
   schedulingConstraints:
     affinity:
       nodeAffinity:


### PR DESCRIPTION
When installing the PostGis extension the PostgreSQL container is OOMKilled. The minimal viable memory limit to prevent this issue is 200Mi.

# Short Description

_Please provide a brief summary of your changes_

# Details

# Note

WARNING: Only users listed in the CODEOWNERS file can approve PRs!

# Checks

- [ ] Documentation has been adjusted
- [ ] Architectural decisions have been documented
- [ ] Changelog has been updated
- [ ] PR is approved by a code owner
- [ ] Manifests are updated
- [ ] Commit message adheres to our [guideline](https://anynines.atlassian.net/wiki/spaces/DS/pages/2423193626/Version+Control+Workflow)
