### PR TITLE
Update S3-Compatible support backup manager support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Added
+
+* Backup-manager now supports S3-compatible storage services, allowing users to back up and restore
+  data with any S3-compatible provider.
+
 ### Updated
 
 * Bump Operator-SDK version to v1.34.2 for postgresql-operator

--- a/deploy/a8s/manifests/backup-manager.yaml
+++ b/deploy/a8s/manifests/backup-manager.yaml
@@ -636,7 +636,7 @@ spec:
               fieldPath: metadata.namespace
         - name: BACKUP_CREDENTIAL_PATH
           value: /etc/backup-store-secrets
-        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/backup-manager:2616f22c4fe670541c3c78131aw018902e847rbf
+        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/backup-manager:8ef669ad8768cd03b9dccce27bf55fd1e034239a
         livenessProbe:
           httpGet:
             path: /healthz

--- a/docs/platform-operators/installing_framework.md
+++ b/docs/platform-operators/installing_framework.md
@@ -3,6 +3,7 @@
 - [Install the a8s Control Plane](#install-the-a8s-control-plane)
   - [Prerequisites](#prerequisites)
     - [Configure Backups Store](#configure-backups-store)
+    - [Configure S3-Compatible Backups Store](#configure-s3-compatible-backups-store)
   - [Configure Images](#configure-images)
   - [Install the a8s Control Plane](#install-the-a8s-control-plane-1)
     - [Using Static Manifests](#using-static-manifests)
@@ -59,6 +60,32 @@ Then, use an editor to open `deploy/a8s/backup-config/backup-store-config.yaml` 
 
 All the created files are gitignored so you don't have to worry about committing them by mistake
 (since they contain private data).
+
+### Configure S3-Compatible Backup Store (Optional)
+
+Alternatively, the framework supports taking backups to any S3-compatible backup store, which can be useful for local testing. This requires installing and configuring a local S3-compatible backup store, such as MinIO, separately.
+
+```shell
+# create file that stores the ID of the key
+echo -n <bucket-access-key-id> > deploy/a8s/backup-config/access-key-id
+
+# create file that stores the secret value of the key
+echo -n <bucket-secret-access-key> > deploy/a8s/backup-config/secret-access-key
+
+# create file that stores password for backup encryption
+echo -n <encryption password> > deploy/a8s/backup-config/encryption-password
+
+# create file with other information about the bucket
+cp deploy/a8s/backup-config/backup-store-config.yaml.template deploy/a8s/backup-config/backup-store-config.yaml
+```
+
+Next, use an editor to open `deploy/a8s/backup-config/backup-store-config.yaml` and replace the value:
+
+- Of the `container` field with the name of the S3 bucket.
+- Add `path_style` set to `True`.
+- Add `endpoint` with the URL for the S3-compatible service, for example, `http://test-hl.default.svc.cluster.local:9000`.
+
+All the created files are gitignored, so you don't have to worry about committing them by mistake (since they contain private data).
 
 ## Configure Images
 


### PR DESCRIPTION
# Short Description

This PR adds support for S3-compatible backends - https://github.com/anynines/a8s-backup-manager/pull/81. The feature is required for running the CLI demo locally without S3.

- I ran all the e2e tests locally to ensure no regressions with existing functionality
- I tested with MinIO as a S3 store for backups and updated docs

# Details

# Note

WARNING: Only users listed in the CODEOWNERS file can approve PRs!

# Checks

- [x] Documentation has been adjusted
- [ ] ~~Architectural decisions have been documented~~
- [x] Changelog has been updated
- [ ] PR is approved by a code owner
- [ ] ~~Manifests are updated~~
- [ ] Commit message adheres to our [guideline](https://anynines.atlassian.net/wiki/spaces/DS/pages/2423193626/Version+Control+Workflow)
