### PR TITLE
A9s 2529 keycloak production indexer fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
 * Bump Operator-SDK version to v1.34.1 for a8s-backup-manager
 * Remove hard-coded start commands from deployment manifests
 
+### Fixed
+
+* Fix nil pointer dereference in OwnerUIDExtractor indexer function of PostgreSQL Operator
+
 ## [1.2.0] - 2024-06-24
 
 ### Added

--- a/deploy/a8s/manifests/postgresql-operator.yaml
+++ b/deploy/a8s/manifests/postgresql-operator.yaml
@@ -1807,7 +1807,7 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
-        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/postgresql-operator:32cff0ecbc54763a3bf8a4079b1d2db9b1f26754
+        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/postgresql-operator:0fc9dd37054a60cc83699ff604774073f3cfd9d7
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Bump postgresql-operator version, generate new manifests for
deploying postgresql-operator and update API documentation to
integrate PR A9s 2529 keycloak production indexer fix
