### PR TITLE
[A8S-2387] Restore file based manager configuration

### DIFF
--- a/deploy/a8s/manifests/service-binding-controller.yaml
+++ b/deploy/a8s/manifests/service-binding-controller.yaml
@@ -336,17 +336,14 @@ subjects:
 apiVersion: v1
 data:
   controller_manager_config.yaml: |
-    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    apiVersion: config.servicebindings.anynines.com/v1beta3
     kind: ControllerManagerConfig
     health:
       healthProbeBindAddress: :8081
     metrics:
       bindAddress: 127.0.0.1:8080
-    webhook:
-      port: 9443
     leaderElection:
       leaderElect: true
-      resourceName: 875d0b65.anynines.com
 kind: ConfigMap
 metadata:
   name: service-binding-manager-config
@@ -412,12 +409,10 @@ spec:
     spec:
       containers:
       - args:
+        - --config=/config/controller_manager_config.yaml
         - --postgresql-root-role=a9s_user
         - --postgresql-default-database=a9s_apps_default_db
-        - --health-probe-bind-address=:8081
-        - --metrics-bind-address=127.0.0.1:8080
-        - --leader-elect
-        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/service-binding-controller:0caabf0e1a159662c3830a042c94da36995d221a
+        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/service-binding-controller:454b3551dad39fe63da11ddcc7972b95fb318476
         livenessProbe:
           httpGet:
             path: /healthz

--- a/docs/platform-operators/config-documentation/a8s-service-binding-controller/v1beta3.md
+++ b/docs/platform-operators/config-documentation/a8s-service-binding-controller/v1beta3.md
@@ -1,0 +1,60 @@
+# API Reference
+
+## Packages
+- [config.servicebindings.anynines.com/v1beta3](#configservicebindingsanyninescomv1beta3)
+
+## config.servicebindings.anynines.com/v1beta3
+
+Package v1beta3 contains API Schema definitions for the config v1beta3 API group
+
+### Resource Types
+- [ControllerManagerConfig](#controllermanagerconfig)
+
+#### ControllerHealth
+
+ControllerHealth defines the health configs.
+
+_Appears in:_
+- [ControllerManagerConfig](#controllermanagerconfig)
+
+| Field | Description |
+| --- | --- |
+| `healthProbeBindAddress` _string_ | HealthProbeBindAddress is the TCP address that the controller should bind to for serving health probes It can be set to "0" or "" to disable serving the health probe. Defaults to ":8081". |
+| `readinessEndpointName` _string_ | Readiness endpoint name. Must start with a '/'. |
+| `livenessEndpointName` _string_ | Liveness endpoint name. Must start with a '/'. |
+
+#### ControllerManagerConfig
+
+ControllerManagerConfig is the Schema for the manager's configuration API
+
+| Field | Description |
+| --- | --- |
+| `apiVersion` _string_ | `config.servicebindings.anynines.com/v1beta3`
+| `kind` _string_ | `ControllerManagerConfig`
+| `leaderElection` _[LeaderElection](#leaderelection)_ | LeaderElection contains the leader election configuration |
+| `metrics` _[ControllerMetrics](#controllermetrics)_ | Metrics contains the controller metrics configuration |
+| `health` _[ControllerHealth](#controllerhealth)_ | Health contains the controller health configuration |
+
+#### ControllerMetrics
+
+ControllerMetrics defines the metrics configs.
+
+_Appears in:_
+- [ControllerManagerConfig](#controllermanagerconfig)
+
+| Field | Description |
+| --- | --- |
+| `bindAddress` _string_ | BindAddress is the TCP address that the controller should bind to for serving prometheus metrics. It can be set to "0" to disable the metrics serving. Defaults to "":8080". |
+
+#### LeaderElection
+
+LeaderElection defines the leader election configs.
+
+_Appears in:_
+- [ControllerManagerConfig](#controllermanagerconfig)
+
+| Field | Description |
+| --- | --- |
+| `leaderElect` _boolean_ | leaderElect enables a leader election client to gain leadership before executing the main loop. Enable this when running replicated components for high availability. |
+| `leaderElectionNamespace` _string_ | LeaderElectionNamespace indicates the namespace of resource object that will be used to lock during leader election cycles. |
+


### PR DESCRIPTION
Bump service-binding-controller version, generate new manifests for
deploying service-binding-controller and update API documentation to
integrate PR [A8S-2387] Restore file based manager configuration


[A8S-2387]: https://anynines.atlassian.net/browse/A8S-2387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ