### PR TITLE
Reduce platforms and simplify Docker build process

### DIFF
--- a/deploy/a8s/manifests/service-binding-controller.yaml
+++ b/deploy/a8s/manifests/service-binding-controller.yaml
@@ -412,12 +412,10 @@ spec:
     spec:
       containers:
       - args:
-        - --postgresql-root-role=a9s_user
-        - --postgresql-default-database=a9s_apps_default_db
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
-        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/service-binding-controller:0caabf0e1a159662c3830a042c94da36995d221a
+        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/service-binding-controller:0b0061c183067799dfb98830bc103407c5d5771c
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Bump service-binding-controller version, generate new manifests for
deploying service-binding-controller and update API documentation to
integrate PR Reduce platforms and simplify Docker build process
