### PR TITLE
[do not merge] a8s-2657 Test docs gen pipeline 2

### DIFF
--- a/deploy/a8s/manifests/postgresql-operator.yaml
+++ b/deploy/a8s/manifests/postgresql-operator.yaml
@@ -1807,7 +1807,9 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
-        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/postgresql-operator:0fc9dd37054a60cc83699ff604774073f3cfd9d7
+        command:
+        - ./manager
+        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/postgresql-operator:fb7722a3617339c47e0274783a5810d971191918
         livenessProbe:
           httpGet:
             path: /healthz

--- a/docs/application-developers/api-documentation/postgresql-operator/v1beta3.md
+++ b/docs/application-developers/api-documentation/postgresql-operator/v1beta3.md
@@ -82,7 +82,7 @@ _Appears in:_
 
 #### PostgresqlSpec
 
-PostgresqlSpec defines the desired state of Postgresql.
+PostgresqlSpec defines the desired state of Postgresql. TEST: This is a pipeline test..
 
 _Appears in:_
 - [Postgresql](#postgresql)


### PR DESCRIPTION
Bump postgresql-operator version, generate new manifests for
deploying postgresql-operator and update API documentation to
integrate PR [do not merge] a8s-2657 Test docs gen pipeline 2
