### PR TITLE
Test API Config pipeline

### DIFF
--- a/deploy/a8s/manifests/postgresql-operator.yaml
+++ b/deploy/a8s/manifests/postgresql-operator.yaml
@@ -1807,7 +1807,7 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
-        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/postgresql-operator:0fc9dd37054a60cc83699ff604774073f3cfd9d7
+        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/postgresql-operator:b8204fae8c95a00d147814c5001636a77ed17baa
         livenessProbe:
           httpGet:
             path: /healthz

--- a/docs/application-developers/api-documentation/postgresql-operator/v1beta3.md
+++ b/docs/application-developers/api-documentation/postgresql-operator/v1beta3.md
@@ -82,7 +82,7 @@ _Appears in:_
 
 #### PostgresqlSpec
 
-PostgresqlSpec defines the desired state of Postgresql.
+PostgresqlSpec defines the desired state of Postgresql. TEST!
 
 _Appears in:_
 - [Postgresql](#postgresql)


### PR DESCRIPTION
Bump postgresql-operator version, generate new manifests for
deploying postgresql-operator and update API documentation to
integrate PR Test API Config pipeline
