### PR TITLE
Test API config pipeline

### DIFF
--- a/deploy/a8s/manifests/service-binding-controller.yaml
+++ b/deploy/a8s/manifests/service-binding-controller.yaml
@@ -412,7 +412,7 @@ spec:
         - --config=/config/controller_manager_config.yaml
         - --postgresql-root-role=a9s_user
         - --postgresql-default-database=a9s_apps_default_db
-        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/service-binding-controller:454b3551dad39fe63da11ddcc7972b95fb318476
+        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/service-binding-controller:c0577843cb54282fb9e01ed3d7fa4b5ada001e82
         livenessProbe:
           httpGet:
             path: /healthz

--- a/docs/application-developers/api-documentation/a8s-service-binding-controller/v1beta3.md
+++ b/docs/application-developers/api-documentation/a8s-service-binding-controller/v1beta3.md
@@ -65,7 +65,7 @@ ServiceBindingList contains a list of ServiceBinding.
 
 #### ServiceBindingSpec
 
-ServiceBindingSpec defines the desired state of the ServiceBinding.
+ServiceBindingSpec defines the desired state of the ServiceBinding. TEST!
 
 _Appears in:_
 - [ServiceBinding](#servicebinding)


### PR DESCRIPTION
Bump service-binding-controller version, generate new manifests for
deploying service-binding-controller and update API documentation to
integrate PR Test API config pipeline
