### PR TITLE
add RF as Code Owner

### DIFF
--- a/deploy/a8s/manifests/postgresql-operator.yaml
+++ b/deploy/a8s/manifests/postgresql-operator.yaml
@@ -1807,7 +1807,7 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
-        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/postgresql-operator:1761ccfa05638862c161fe1d32b2a67e1621ef8b
+        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/postgresql-operator:354cbe11c890c261b787b9bf903836a9e3cfaae5
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Bump postgresql-operator version, generate new manifests for
deploying postgresql-operator and update API documentation to
integrate PR add RF as Code Owner
