### PR TITLE
Increase timeouts for e2e tests to prevent Tekton failures

### DIFF
--- a/test/e2e/backuppolicy/backuppolicy_test.go
+++ b/test/e2e/backuppolicy/backuppolicy_test.go
@@ -19,7 +19,7 @@ const (
 	replicas            = 1
 	suffixLength        = 5
 	pollingPeriod       = 1 * time.Second
-	asyncOpsTimeoutMins = time.Minute * 2
+	asyncOpsTimeoutMins = time.Minute * 5
 )
 
 var (
@@ -45,7 +45,6 @@ var _ = Describe("BackupPolicy", func() {
 	})
 
 	AfterEach(func() {
-
 		Expect(k8sClient.Delete(ctx, backupPolicy)).To(Succeed(),
 			fmt.Sprintf("failed to delete backup policy %s/%s",
 				backupPolicy.GetNamespace(), backupPolicy.GetName()))

--- a/test/e2e/postgresql/exposed_cluster_test.go
+++ b/test/e2e/postgresql/exposed_cluster_test.go
@@ -119,7 +119,7 @@ var _ = Describe("end-to-end tests for exposed instances", Label("ExternalLoadba
 			// to become available from the internet
 			Eventually(func() error {
 				return client.Write(ctx, entity, testInput)
-			}, 5*time.Minute).Should(Succeed())
+			}, asyncOpsTimeoutMins).Should(Succeed())
 		})
 
 		It("can read data via public address", func() {
@@ -139,7 +139,7 @@ var _ = Describe("end-to-end tests for exposed instances", Label("ExternalLoadba
 				entityData, err := client.Read(ctx, entity)
 				g.Expect(err).To(BeNil(), "error reading from the instances primary service")
 				g.Expect(entityData).To(Equal(testInput), "data service returned unexpected entry")
-			}, 5*time.Minute).Should(Succeed())
+			}, asyncOpsTimeoutMins).Should(Succeed())
 
 			By("allowing reading from read-only service")
 
@@ -158,7 +158,7 @@ var _ = Describe("end-to-end tests for exposed instances", Label("ExternalLoadba
 				entityData, err := client.Read(ctx, entity)
 				g.Expect(err).To(BeNil(), "error reading from the instances read-only service")
 				g.Expect(entityData).To(Equal(testInput), "data service returned unexpected entry")
-			}, 5*time.Minute).Should(Succeed())
+			}, asyncOpsTimeoutMins).Should(Succeed())
 		})
 	})
 })

--- a/test/e2e/postgresql/postgresql_test.go
+++ b/test/e2e/postgresql/postgresql_test.go
@@ -46,7 +46,7 @@ const (
 	// entity is a generic term to describe where data services store their data.
 	entity = "test_entity"
 	// asyncOpsTimeoutMins...
-	asyncOpsTimeoutMins = time.Minute * 5
+	asyncOpsTimeoutMins = time.Minute * 10
 )
 
 var (

--- a/test/e2e/topology_awareness/topology_awareness_test.go
+++ b/test/e2e/topology_awareness/topology_awareness_test.go
@@ -39,6 +39,8 @@ const (
 	taintingTimeout = 5 * time.Second
 	labelingTimeout = 5 * time.Second
 	listingTimeout  = 5 * time.Second
+
+	asyncOpsTimeoutMins = time.Minute * 15
 )
 
 var _ = Describe("DSIs topology awareness", func() {
@@ -126,7 +128,7 @@ var _ = Describe("DSIs topology awareness", func() {
 						g.Expect(sset.Status.ReadyReplicas).To(Equal(replicas),
 							"ready replicas of DSI "+instanceNSN+
 								"'s StatefulSet don't match DSI's desired replicas")
-					}, 5*time.Minute).Should(Succeed(),
+					}, asyncOpsTimeoutMins).Should(Succeed(),
 						"failed to verify that the DSI's StatefulSet gets up and running")
 				})
 
@@ -205,7 +207,7 @@ var _ = Describe("DSIs topology awareness", func() {
 						g.Expect(sset.Status.ReadyReplicas).To(Equal(replicas),
 							"ready replicas of DSI "+instanceNSN+
 								"'s StatefulSet don't match DSI's desired replicas")
-					}, 5*time.Minute).Should(Succeed(),
+					}, asyncOpsTimeoutMins).Should(Succeed(),
 						"failed to verify that the DSI's StatefulSet gets up and running")
 				})
 
@@ -318,7 +320,7 @@ var _ = Describe("DSIs topology awareness", func() {
 						g.Expect(sset.Status.ReadyReplicas).To(Equal(replicas),
 							"ready replicas of DSI "+instanceNSN+
 								"'s StatefulSet don't match DSI's desired replicas")
-					}, 5*time.Minute).Should(Succeed(),
+					}, asyncOpsTimeoutMins).Should(Succeed(),
 						"failed to verify that the DSI's StatefulSet gets up and running")
 				})
 
@@ -397,7 +399,7 @@ var _ = Describe("DSIs topology awareness", func() {
 						g.Expect(sset.Status.ReadyReplicas).To(Equal(replicas),
 							"ready replicas of DSI "+instanceNSN+
 								"'s StatefulSet don't match DSI's desired replicas")
-					}, 5*time.Minute).Should(Succeed(),
+					}, asyncOpsTimeoutMins).Should(Succeed(),
 						"failed to verify that the DSI's StatefulSet gets up and running")
 				})
 

--- a/test/framework/backuppolicy/backuppolicy.go
+++ b/test/framework/backuppolicy/backuppolicy.go
@@ -17,7 +17,7 @@ const (
 	// they check has not become true. Needed because some conditions might become true only
 	// after some time, so we need to check them asynchronously.
 	// TODO: Make asyncOpsTimeoutMins an invocation parameter.
-	asyncOpsTimeoutMins = time.Minute * 2
+	asyncOpsTimeoutMins = time.Minute * 5
 	suffixLength        = 6
 	pollingPeriod       = 1 * time.Second
 )


### PR DESCRIPTION
Updated the timeout settings for the Tekton CI cluster to ensure that end-to-end (e2e) tests complete successfully without timing out. This change addresses issues where long-running tests were failing due to insufficient timeout values.

Timeouts were roughly derived by looking at the execution time of the various test suites on the [Tekton Dashboard](https://tekton.ci.a8s-dev.a9s.eu/#/namespaces/tekton-pipelines/pipelineruns/e2e-test-pipeline-run-mqc8s?pipelineTask=run-tests&step=run-tests).

```
ok  	[github.com/anynines/a8s-deployment/test/e2e/backup](http://github.com/anynines/a8s-deployment/test/e2e/backup)	70.351s
ok  	[github.com/anynines/a8s-deployment/test/e2e/backuppolicy](http://github.com/anynines/a8s-deployment/test/e2e/backuppolicy)	213.893s
ok  	[github.com/anynines/a8s-deployment/test/e2e/patroni](http://github.com/anynines/a8s-deployment/test/e2e/patroni)	66.721s
ok  	[github.com/anynines/a8s-deployment/test/e2e/postgresql](http://github.com/anynines/a8s-deployment/test/e2e/postgresql)	697.839s
ok  	[github.com/anynines/a8s-deployment/test/e2e/postgresql/webhooks/v1beta3](http://github.com/anynines/a8s-deployment/test/e2e/postgresql/webhooks/v1beta3)	20.400s
ok  	[github.com/anynines/a8s-deployment/test/e2e/servicebinding](http://github.com/anynines/a8s-deployment/test/e2e/servicebinding)	111.279s
ok  	[github.com/anynines/a8s-deployment/test/e2e/topology_awareness](http://github.com/anynines/a8s-deployment/test/e2e/topology_awareness)	633.883s
```

# Short Description

_Please provide a brief summary of your changes_

# Details

# Note

WARNING: Only users listed in the CODEOWNERS file can approve PRs!

# Checks

- [ ] Documentation has been adjusted
- [ ] Architectural decisions have been documented
- [ ] Changelog has been updated
- [ ] PR is approved by a code owner
- [ ] Manifests are updated
- [ ] Commit message adheres to our [guideline](https://anynines.atlassian.net/wiki/spaces/DS/pages/2423193626/Version+Control+Workflow)
