### PR TITLE
Update pgx dependency to fix GO-2024-2606 found by govulncheck

### DIFF
--- a/deploy/a8s/manifests/postgresql-operator.yaml
+++ b/deploy/a8s/manifests/postgresql-operator.yaml
@@ -1807,7 +1807,7 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
-        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/postgresql-operator:1761ccfa05638862c161fe1d32b2a67e1621ef8b
+        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/postgresql-operator:632d76a100fb9f24f7297e0be229d7ca5d96078e
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Bump postgresql-operator version, generate new manifests for
deploying postgresql-operator and update API documentation to
integrate PR Update pgx dependency to fix GO-2024-2606 found by govulncheck
