### PR TITLE
Bumps chaos-mesh to release version 2.7

### DIFF
--- a/test/go.mod
+++ b/test/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/anynines/a8s-backup-manager v0.42.1-0.20240808121834-50ac6e406efc
 	github.com/anynines/a8s-service-binding-controller v0.37.1-0.20230423204020-a2903616cb2f
 	github.com/anynines/postgresql-operator v0.89.0
-	github.com/chaos-mesh/chaos-mesh/api v0.0.0-20230209235359-64dc83baed9b
+	github.com/chaos-mesh/chaos-mesh/api v0.0.0-20241018161350-b08de63dc44b
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0
 	github.com/jackc/pgx/v5 v5.7.1

--- a/test/go.sum
+++ b/test/go.sum
@@ -21,8 +21,8 @@ github.com/bxcodec/faker v2.0.1+incompatible/go.mod h1:BNzfpVdTwnFJ6GtfYTcQu6l6r
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chaos-mesh/chaos-mesh/api v0.0.0-20230209235359-64dc83baed9b h1:am6IJSVZb/JIMffv4bOJ+BwPbrnwUovCTVP/gY38F1Q=
-github.com/chaos-mesh/chaos-mesh/api v0.0.0-20230209235359-64dc83baed9b/go.mod h1:tMUOEjRuThuozqrIDKhyViTZXaEZhIVV18/cSiGC3NQ=
+github.com/chaos-mesh/chaos-mesh/api v0.0.0-20241018161350-b08de63dc44b h1:kgwUURHUIosKm27r21U33oTpaDxTjg+YpZE3hY7UK/0=
+github.com/chaos-mesh/chaos-mesh/api v0.0.0-20241018161350-b08de63dc44b/go.mod h1:x11iCbZV6hzzSQWMq610B6Wl5Lg1dhwqcVfeiWQQnQQ=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=


### PR DESCRIPTION
# Short Description

The chaos-mesh API version for the chaos-tests was updated to the release version 2.7

# Details

# Note

WARNING: Only users listed in the CODEOWNERS file can approve PRs!

# Checks

- [ ] Documentation has been adjusted
- [ ] Architectural decisions have been documented
- [ ] Changelog has been updated
- [ ] PR is approved by a code owner
- [ ] Manifests are updated
- [ ] Commit message adheres to our [guideline](https://anynines.atlassian.net/wiki/spaces/DS/pages/2423193626/Version+Control+Workflow)
