### PR TITLE
fix: default DSI namespace to ServiceBinding for proper reconciliation

### DIFF
--- a/deploy/a8s/manifests/service-binding-controller.yaml
+++ b/deploy/a8s/manifests/service-binding-controller.yaml
@@ -412,7 +412,7 @@ spec:
         - --config=/config/controller_manager_config.yaml
         - --postgresql-root-role=a9s_user
         - --postgresql-default-database=a9s_apps_default_db
-        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/service-binding-controller:454b3551dad39fe63da11ddcc7972b95fb318476
+        image: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/service-binding-controller:9de39c317e557a593ade033e9e98e0c7d8e5e238
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Bump service-binding-controller version, generate new manifests for
deploying service-binding-controller and update API documentation to
integrate PR fix: default DSI namespace to ServiceBinding for proper reconciliation
