### PR TITLE
Move CRDs to templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
-* Use templates for CRDs in helm charts. Add `crd.install` and `crd.keep` variables.
+* Use templates for CRDs in helm charts. Add `crd.enable` and `crd.keep` variables.
 
 ## [1.3.0] - 2026-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+* Use templates for CRDs in helm charts. Add `crd.install` and `crd.keep` variables.
+
 ## [1.3.0] - 2026-04-08
 
 ### Added

--- a/deploy/a8s/charts/a8s-backup-manager/Chart.yaml
+++ b/deploy/a8s/charts/a8s-backup-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: backup-manager
 description: Helm chart for the a8s backup manager
-version: 0.1.0
+version: 0.2.0
 appVersion: "a855999"
 type: application

--- a/deploy/a8s/charts/a8s-backup-manager/README.md
+++ b/deploy/a8s/charts/a8s-backup-manager/README.md
@@ -90,6 +90,8 @@ kubectl create secret generic a8s-backup-storage-credentials \
 
 Key configurable values:
 
+- `crd.install`: Install CRDs via Helm
+- `crd.keep`: Keep CRDs on uninstall (avoids potential data loss)
 - `image.repository`: Docker image repository
 - `image.tag`: Image tag/version
 - `replicaCount`: Number of backup-manager replicas

--- a/deploy/a8s/charts/a8s-backup-manager/README.md
+++ b/deploy/a8s/charts/a8s-backup-manager/README.md
@@ -90,7 +90,7 @@ kubectl create secret generic a8s-backup-storage-credentials \
 
 Key configurable values:
 
-- `crd.install`: Install CRDs via Helm
+- `crd.enable`: Install CRDs via Helm
 - `crd.keep`: Keep CRDs on uninstall (avoids potential data loss)
 - `image.repository`: Docker image repository
 - `image.tag`: Image tag/version

--- a/deploy/a8s/charts/a8s-backup-manager/templates/crd/backuppolicies.backups.anynines.com.yaml
+++ b/deploy/a8s/charts/a8s-backup-manager/templates/crd/backuppolicies.backups.anynines.com.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.crd.install }}
+{{- if .Values.crd.enable }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/deploy/a8s/charts/a8s-backup-manager/templates/crd/backuppolicies.backups.anynines.com.yaml
+++ b/deploy/a8s/charts/a8s-backup-manager/templates/crd/backuppolicies.backups.anynines.com.yaml
@@ -1,8 +1,12 @@
+{{- if .Values.crd.install }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+{{- if .Values.crd.keep }}
+    helm.sh/resource-policy: keep
+{{- end }}
     controller-gen.kubebuilder.io/version: v0.17.3
   name: backuppolicies.backups.anynines.com
 spec:
@@ -187,3 +191,4 @@ spec:
       storage: true
       subresources:
         status: {}
+{{- end }}

--- a/deploy/a8s/charts/a8s-backup-manager/templates/crd/backups.backups.anynines.com.yaml
+++ b/deploy/a8s/charts/a8s-backup-manager/templates/crd/backups.backups.anynines.com.yaml
@@ -1,7 +1,11 @@
+{{- if .Values.crd.install }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+{{- if .Values.crd.keep }}
+    helm.sh/resource-policy: keep
+{{- end }}
     controller-gen.kubebuilder.io/version: v0.17.3
   name: backups.backups.anynines.com
 spec:
@@ -173,3 +177,4 @@ spec:
       storage: true
       subresources:
         status: {}
+{{- end }}

--- a/deploy/a8s/charts/a8s-backup-manager/templates/crd/backups.backups.anynines.com.yaml
+++ b/deploy/a8s/charts/a8s-backup-manager/templates/crd/backups.backups.anynines.com.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.crd.install }}
+{{- if .Values.crd.enable }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/a8s/charts/a8s-backup-manager/templates/crd/restores.backups.anynines.com.yaml
+++ b/deploy/a8s/charts/a8s-backup-manager/templates/crd/restores.backups.anynines.com.yaml
@@ -1,7 +1,11 @@
+{{- if .Values.crd.install }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+{{- if .Values.crd.keep }}
+    helm.sh/resource-policy: keep
+{{- end }}
     controller-gen.kubebuilder.io/version: v0.17.3
   name: restores.backups.anynines.com
 spec:
@@ -177,3 +181,4 @@ spec:
       storage: true
       subresources:
         status: {}
+{{- end }}

--- a/deploy/a8s/charts/a8s-backup-manager/templates/crd/restores.backups.anynines.com.yaml
+++ b/deploy/a8s/charts/a8s-backup-manager/templates/crd/restores.backups.anynines.com.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.crd.install }}
+{{- if .Values.crd.enable }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/a8s/charts/a8s-backup-manager/values.yaml
+++ b/deploy/a8s/charts/a8s-backup-manager/values.yaml
@@ -2,7 +2,7 @@ namespace: a8s-system
 replicaCount: 1
 
 crd:
-  install: true
+  enable: true
   keep: true
 
 image:

--- a/deploy/a8s/charts/a8s-backup-manager/values.yaml
+++ b/deploy/a8s/charts/a8s-backup-manager/values.yaml
@@ -1,6 +1,10 @@
 namespace: a8s-system
 replicaCount: 1
 
+crd:
+  install: true
+  keep: true
+
 image:
   repository: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/backup-manager
   tag: a8555999c8c6fd7a1544c599b47f458b172eb4ca

--- a/deploy/a8s/charts/a8s-postgresql-operator/Chart.yaml
+++ b/deploy/a8s/charts/a8s-postgresql-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: postgresql-operator
 description: Helm chart for the a8s PostgreSQL operator
-version: 0.1.0
+version: 0.2.0
 appVersion: "0dc360e"
 type: application

--- a/deploy/a8s/charts/a8s-postgresql-operator/README.md
+++ b/deploy/a8s/charts/a8s-postgresql-operator/README.md
@@ -79,6 +79,8 @@ Key configurable values:
 |-----------|---------|-------------|
 | `namespace` | `a8s-system` | Kubernetes namespace for the operator |
 | `replicaCount` | `1` | Number of operator replicas |
+| `crd.install` | `true` | Install CRDs via Helm |
+| `crd.keep` | `true` | Keep CRDs on uninstall (avoids potential data loss) |
 | `image.repository` | ECR public registry | Docker image repository |
 | `image.tag` | `a8555999c8c6fd7a1544c599b47f458b172eb4ca` | Image tag/version |
 | `image.pullPolicy` | `IfNotPresent` | Image pull policy |

--- a/deploy/a8s/charts/a8s-postgresql-operator/README.md
+++ b/deploy/a8s/charts/a8s-postgresql-operator/README.md
@@ -79,7 +79,7 @@ Key configurable values:
 |-----------|---------|-------------|
 | `namespace` | `a8s-system` | Kubernetes namespace for the operator |
 | `replicaCount` | `1` | Number of operator replicas |
-| `crd.install` | `true` | Install CRDs via Helm |
+| `crd.enable` | `true` | Install CRDs via Helm |
 | `crd.keep` | `true` | Keep CRDs on uninstall (avoids potential data loss) |
 | `image.repository` | ECR public registry | Docker image repository |
 | `image.tag` | `a8555999c8c6fd7a1544c599b47f458b172eb4ca` | Image tag/version |

--- a/deploy/a8s/charts/a8s-postgresql-operator/templates/crd/postgresqls.postgresql.anynines.com.yaml
+++ b/deploy/a8s/charts/a8s-postgresql-operator/templates/crd/postgresqls.postgresql.anynines.com.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.crd.install }}
+{{- if .Values.crd.enable }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/a8s/charts/a8s-postgresql-operator/templates/crd/postgresqls.postgresql.anynines.com.yaml
+++ b/deploy/a8s/charts/a8s-postgresql-operator/templates/crd/postgresqls.postgresql.anynines.com.yaml
@@ -1,8 +1,12 @@
+{{- if .Values.crd.install }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: a8s-system/postgresql-serving-cert
+{{- if .Values.crd.keep }}
+    helm.sh/resource-policy: keep
+{{- end }}
     controller-gen.kubebuilder.io/version: v0.17.3
   name: postgresqls.postgresql.anynines.com
 spec:
@@ -1496,3 +1500,4 @@ spec:
           specReplicasPath: .spec.replicas
           statusReplicasPath: .status.readyReplicas
         status: {}
+{{- end }}

--- a/deploy/a8s/charts/a8s-postgresql-operator/values.yaml
+++ b/deploy/a8s/charts/a8s-postgresql-operator/values.yaml
@@ -1,6 +1,10 @@
 namespace: a8s-system
 replicaCount: 1
 
+crd:
+  install: true
+  keep: true
+
 image:
   repository: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/postgresql-operator
   tag: 0dc360e4590ff6fb7f86927f1a48422790b0a9c9

--- a/deploy/a8s/charts/a8s-postgresql-operator/values.yaml
+++ b/deploy/a8s/charts/a8s-postgresql-operator/values.yaml
@@ -2,7 +2,7 @@ namespace: a8s-system
 replicaCount: 1
 
 crd:
-  install: true
+  enable: true
   keep: true
 
 image:

--- a/deploy/a8s/charts/a8s-service-binding-controller/Chart.yaml
+++ b/deploy/a8s/charts/a8s-service-binding-controller/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: service-binding-controller
 description: Helm chart for deploying the service binding controller
-version: 0.1.1
+version: 0.2.0
 appVersion: "af0fb737"
 type: application

--- a/deploy/a8s/charts/a8s-service-binding-controller/README.md
+++ b/deploy/a8s/charts/a8s-service-binding-controller/README.md
@@ -76,7 +76,7 @@ Key configurable values:
 |-----------|---------|-------------|
 | `namespace` | `a8s-system` | Kubernetes namespace for the controller |
 | `replicaCount` | `1` | Number of controller replicas |
-| `crd.install` | `true` | Install CRDs via Helm |
+| `crd.enable` | `true` | Install CRDs via Helm |
 | `crd.keep` | `true` | Keep CRDs on uninstall (avoids potential data loss) |
 | `image.repository` | ECR public registry | Docker image repository |
 | `image.tag` | `a8555999c8c6fd7a1544c599b47f458b172eb4ca` | Image tag/version |

--- a/deploy/a8s/charts/a8s-service-binding-controller/README.md
+++ b/deploy/a8s/charts/a8s-service-binding-controller/README.md
@@ -76,6 +76,8 @@ Key configurable values:
 |-----------|---------|-------------|
 | `namespace` | `a8s-system` | Kubernetes namespace for the controller |
 | `replicaCount` | `1` | Number of controller replicas |
+| `crd.install` | `true` | Install CRDs via Helm |
+| `crd.keep` | `true` | Keep CRDs on uninstall (avoids potential data loss) |
 | `image.repository` | ECR public registry | Docker image repository |
 | `image.tag` | `a8555999c8c6fd7a1544c599b47f458b172eb4ca` | Image tag/version |
 | `image.pullPolicy` | `IfNotPresent` | Image pull policy |

--- a/deploy/a8s/charts/a8s-service-binding-controller/templates/crd/servicebindings.servicebindings.anynines.com.yaml
+++ b/deploy/a8s/charts/a8s-service-binding-controller/templates/crd/servicebindings.servicebindings.anynines.com.yaml
@@ -1,7 +1,11 @@
+{{- if .Values.crd.install }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+{{- if .Values.crd.keep }}
+    helm.sh/resource-policy: keep
+{{- end }}
     controller-gen.kubebuilder.io/version: v0.18.0
   name: servicebindings.servicebindings.anynines.com
 spec:
@@ -122,3 +126,4 @@ spec:
       storage: true
       subresources:
         status: {}
+{{- end }}

--- a/deploy/a8s/charts/a8s-service-binding-controller/templates/crd/servicebindings.servicebindings.anynines.com.yaml
+++ b/deploy/a8s/charts/a8s-service-binding-controller/templates/crd/servicebindings.servicebindings.anynines.com.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.crd.install }}
+{{- if .Values.crd.enable }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/a8s/charts/a8s-service-binding-controller/values.yaml
+++ b/deploy/a8s/charts/a8s-service-binding-controller/values.yaml
@@ -2,7 +2,7 @@ namespace: a8s-system
 replicaCount: 1
 
 crd:
-  install: true
+  enable: true
   keep: true
 
 image:

--- a/deploy/a8s/charts/a8s-service-binding-controller/values.yaml
+++ b/deploy/a8s/charts/a8s-service-binding-controller/values.yaml
@@ -1,5 +1,10 @@
 namespace: a8s-system
 replicaCount: 1
+
+crd:
+  install: true
+  keep: true
+
 image:
   repository: public.ecr.aws/w5n9a2g2/a9s-ds-for-k8s/dev/service-binding-controller
   tag: af0fb7372bc816094dc534e1557dde15d27a233d


### PR DESCRIPTION
# Short Description

Use `templates` directory for CRDs instead of `crds`. This allows future updates of CRDs via Helm. 

# Details

# Note

WARNING: Only users listed in the CODEOWNERS file can approve PRs!

# Checks

- [ ] Documentation has been adjusted
- [ ] Architectural decisions have been documented
- [ ] Changelog has been updated
- [ ] PR is approved by a code owner
- [ ] Manifests are updated
- [ ] Commit message adheres to our [guideline](https://anynines.atlassian.net/wiki/spaces/DS/pages/2423193626/Version+Control+Workflow)
